### PR TITLE
Fix the title on Metrics JS SDK page

### DIFF
--- a/src/docs/getting-started/js-sdk/metric-manual-instr.mdx
+++ b/src/docs/getting-started/js-sdk/metric-manual-instr.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Tracing with the AWS Distro for OpenTelemetry JavaScript SDK'
+title: 'Metrics on AWS Distro for OpenTelemetry JavaScript SDK'
 description:
-    Learn how to get started with Java Auto-Instrumentation Agent... This package includes the instrumentation agent,
-    instrumentations for all supported libraries and all available data exporters, providing a complete out of the box
-    experience for tracing on AWS. The agent is preconfigured to generate trace IDs compatible with AWS X-Ray, which
-    will also work with any other tracing system, and enables trace propagation using W3C Trace Context, B3, and X-Ray.
+    Metrics auto instrumentation has not been supported in AOT/OpenTelemetry yet. We have to manually instrumenting code
+    in the application to generate application metrics. Here is an example with steps for modifying application code to
+    create metrics with JavaScript SDK.
+
 path: '/docs/getting-started/js-sdk/metric-manual-instr'
 ---
 


### PR DESCRIPTION
The the title typos on JS SDK Metrics page