### PR TITLE
update download page for AWS OTel Collector v1.0.0-rc.1 release

### DIFF
--- a/src/content/Downloads/downloads.yaml
+++ b/src/content/Downloads/downloads.yaml
@@ -1,3 +1,17 @@
+- version: 'AWS Distro for OpenTelemetry Collector Version 1.0.0-rc.1'
+  releaseDate: 'Dec-14-2020'
+  license: 'Apache-2.0'
+  releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases'
+  documentationLink: 'https://github.com/aws-observability/aws-otel-collector/blob/main/README.md'
+  downloadLink: 'https://hub.docker.com/r/amazon/aws-otel-collector'
+
+- version: 'AWS Distro for OpenTelemetry Collector Version 0.5.0'
+  releaseDate: 'Dec-09-2020'
+  license: 'Apache-2.0'
+  releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases'
+  documentationLink: 'https://github.com/aws-observability/aws-otel-collector/blob/main/README.md'
+  downloadLink: 'https://hub.docker.com/r/amazon/aws-otel-collector'
+
 - version: 'AWS Distro for OpenTelemetry Collector Version 0.4.0'
   releaseDate: 'Nov-18-2020'
   license: 'Apache-2.0'


### PR DESCRIPTION
Update the download page for AWS OTel Collector v1.0.0-rc.1 release