### PR TITLE
Explain SDK Exporter config based on Collector config

### DIFF
--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -78,32 +78,28 @@ The configuration of your SDK exporter depends on how you have configured your A
 
 We can use the `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678` environment variable to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
 
-#### Connecting to a collector running locally as a sidecar
+If the collector the application will connect to is running without TLS configured, the `OTEL_EXPORTER_OTLP_INSECURE=True` environment variable is used to disable client transport security for an SDK OTLP exporter’s connection. This will use the gRPC insecure_channel() method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
 
-When the collector is running locally, the `OTEL_EXPORTER_OTLP_INSECURE=True` environment variable is used to disable client transport security for an SDK OTLP exporter’s connection. This will use the gRPC insecure_channel() method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
-
-#### Connecting to a collector running on the internet as a service
-
-If connecting to a gRPC server on the internet running gRPC over TLS, the `OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt` environment variable can be used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method `ssl_channel_credentials()` will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+If the collector the application will connect to is running with TLS configured, the `OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt` environment variable is used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method `ssl_channel_credentials()` will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
 
 #### Examples on running the application
 
-An example of starting an application which connects to a collector running locally:
+Starting an application which connects to a collector running as a sidecar without TLS:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_INSECURE=True opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+$ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
 ```
 
-An example of starting an application which connects to a collector running locally using flask:
+Starting an application which connects to a collector running as a sidecar without TLS using flask:
 
 ```bash
 $ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 FLASK_APP=./my_flask_app.py opentelemetry-instrument -e otlp --ids-generator aws_xray flask run
 ```
 
-An example of starting an application which connects to a collector running as a service:
+Starting an application which connects to a collector running as a service with TLS:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt OTEL_EXPORTER_OTLP_ENDPOINT=https://my-example-awesome-website-with-collector.com opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
 ```
 
 <SectionSeparator />

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -99,7 +99,7 @@ $ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 F
 Starting an application which connects to a collector running as a service with TLS:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt OTEL_EXPORTER_OTLP_ENDPOINT=https://my-example-awesome-website-with-collector.com opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt OTEL_EXPORTER_OTLP_ENDPOINT=collector.service.local opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
 ```
 
 <SectionSeparator />

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -20,7 +20,7 @@ In this tutorial, we introduce you to how to use the auto-instrumentation packag
 
 ## Requirements
 
-Python 3.5+ is required to use OpenTelemetry Python. Check your currently installed Python version using python3 -V.
+Python 3.5+ is required to use OpenTelemetry Python. Check your currently installed Python version using `python3 -V`.
 For more information about supported Python versions, see the [OpenTelemetry Python API package on PyPi](https://pypi.org/project/opentelemetry-api/).
 
 Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see 
@@ -40,12 +40,12 @@ It also provides commands to detect, install, and initialize all instrumentation
 Go to the directory of the application, which currently imports these packages, and run the following commands.
 
 ```bash 
-# Install required packages for instumentation and tracing support for AWS X-Ray 
-pip install opentelemetry-instrumentation==0.16b1
-pip install opentelemetry-exporter-otlp==0.16b1
-pip install opentelemetry-sdk-extension-aws==0.16b1
+$ # Install required packages for instumentation and tracing support for AWS X-Ray
+$ pip install opentelemetry-instrumentation==0.16b1
+$ pip install opentelemetry-exporter-otlp==0.16b1
+$ pip install opentelemetry-sdk-extension-aws==0.16b1
 # Automatically install supported instrumentors for the application's dependencies
-opentelemetry-bootstrap --action=install
+$ opentelemetry-bootstrap --action=install
 ``` 
 
 <SubSectionSeparator />
@@ -53,7 +53,7 @@ opentelemetry-bootstrap --action=install
 ### Setting the global propagators
 
 To allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator. 
-Set the `OTEL_PROPAGATORS` environment variable to use to the AWS X-Ray Propagator.
+Set the `OTEL_PROPAGATORS` environment variable to use the AWS X-Ray Propagator.
 
 ```
 OTEL_PROPAGATORS=aws_xray
@@ -72,41 +72,38 @@ propagators.set_global_textmap(AwsXRayFormat())
 
 ### Run the application 
 
-Auto instrumentation uses the `opentelemetry-instrument` wrapper executable to automatically initialize the installed instrumentors 
-and start the provided application. Environment variables are used to configure the connection to the ADOT Collector and command 
-line arguments are used to configure trace generation for AWS X-Ray.
+Auto instrumentation uses the `opentelemetry-instrument` wrapper executable to automatically initialize the installed instrumentors and start the provided application. Environment variables are used to configure the connection to the ADOT Collector and command line arguments are used to configure trace generation for AWS X-Ray.
 
-<div style="margin: 20px 0">
-    <mark>
-        Please note, we do not recommend using the insecure option. Rather, we recommend configuring either a public or private
-        certificate to authenticate your session before running your application.
-    </mark>
-</div>
+The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).
 
-The `OTEL_EXPORTER_OTLP_INSECURE=True` environment variable is used to disable client transport security for an OTLP 
-exporter’s connection. This will use the gRPC insecure_channel() method as explained in the 
-[gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). 
-This option should never be used in production, non-sidecar deployments.
+We can use the `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678` environment variable to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
 
-If connecting to a gRPC server on the internet running gRPC over TLS, the `OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/cert.pem` environment 
-variable can be used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials 
-at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the 
-gRPC method `ssl_channel_credentials()` will attempt to “retrieve the PEM-encoded root certificates from a default 
-location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+#### Connecting to a collector running locally as a sidecar
 
-Further, we can use the `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678` environment variable to set the address that the exporter will use to connect 
-to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
+When the collector is running locally, the `OTEL_EXPORTER_OTLP_INSECURE=True` environment variable is used to disable client transport security for an SDK OTLP exporter’s connection. This will use the gRPC insecure_channel() method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
 
-An example of starting an application using generic environment variables:
+#### Connecting to a collector running on the internet as a service
 
-```
-OTEL_EXPORTER_OTLP_INSECURE=True opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+If connecting to a gRPC server on the internet running gRPC over TLS, the `OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt` environment variable can be used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method `ssl_channel_credentials()` will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+
+#### Examples on running the application
+
+An example of starting an application which connects to a collector running locally:
+
+```bash
+$ OTEL_EXPORTER_OTLP_INSECURE=True opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
 ```
 
-An example of starting an application using flask:
+An example of starting an application which connects to a collector running locally using flask:
 
+```bash
+$ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 FLASK_APP=./my_flask_app.py opentelemetry-instrument -e otlp --ids-generator aws_xray flask run
 ```
-OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 FLASK_APP=./my_flask_app.py opentelemetry-instrument -e otlp --ids-generator aws_xray flask run
+
+An example of starting an application which connects to a collector running as a service:
+
+```bash
+$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
 ```
 
 <SectionSeparator />

--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -21,18 +21,15 @@ In this tutorial, we will introduce you to how to use the manual instrumentation
 
 ## Requirements
 
-Python 3.5+ is required to use ADOT Python. Check your currently installed python version using `python3 -V`.
-For more information about supported Python versions, see the [OpenTelemetry API Python package on PyPi](https://pypi.org/project/opentelemetry-api/).
-Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see 
-[Getting Started with the AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/collector).
+Python 3.5+ is required to use ADOT Python. Check your currently installed python version using `python3 -V`. For more information about supported Python versions, see the [OpenTelemetry API Python package on PyPi](https://pypi.org/project/opentelemetry-api/). Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see [Getting Started with the AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/collector).
 
 <SectionSeparator />
 
 ## Getting the SDK and dependencies
 
- Install the following packages from OpenTelemetry Python using pip.
+Install the following packages from OpenTelemetry Python using pip.
 
-```
+```bash
 $ pip install opentelemetry-api==0.16b1 \
               opentelemetry-sdk==0.16b1 \
               opentelemetry-exporter-otlp==0.16b1 \
@@ -43,10 +40,10 @@ OpenTelemetry Python distributes many packages, which provide instrumentation fo
 instrumentation package for every dependency you want to generate traces for. To see supported frameworks and libraries, check out 
 the [OpenTelemetry Registry](https://opentelemetry.io/registry/?s=python).
 
-```
+```bash
 # Supported instrumentation packages for the dependencies of the example above
-pip install opentelemetry-instrumentation-flask==0.16b1
-pip install opentelemetry-instrumentation-botocore==0.16b1
+$ pip install opentelemetry-instrumentation-flask==0.16b1
+$ pip install opentelemetry-instrumentation-botocore==0.16b1
 ```
 
 <SectionSeparator />
@@ -72,7 +69,23 @@ from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 from opentelemetry.sdk.extension.aws.trace import AwsXRayIdsGenerator
 ```
 
-Configure the Global Tracer Provider to export to the ADOT Collector.
+Next, configure the Global Tracer Provider to export to the ADOT Collector. The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).
+
+The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
+
+#### Connecting to a collector running locally as a sidecar
+
+The `insecure=True` argument disables client transport security for our OTLP exporter’s connection. This will use the gRPC `insecure_channel()`
+method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel).
+This option should never be used in production, non-sidecar deployments.
+
+#### Connecting to a collector running on the internet as a service
+
+If connecting to a gRPC server on the internet running gRPC over TLS, the `credentials=/path/to/cert.pem` argument can be used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method ssl_channel_credentials() will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+
+#### Example TracerProvider configuration
+
+As an example where we connect to a ADOT Collector running locally deployed as a sidecar, we can setup the TracerProvider as follows:
 
 ```python lineNumbers=true
 # Sends generated traces in the OTLP format to an ADOT Collector running on port 55678
@@ -82,26 +95,6 @@ span_processor = BatchExportSpanProcessor(otlp_exporter)
 # Configures the Global Tracer Provider
 trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor, ids_generator=AwsXRayIdsGenerator()))
 ```
-
-<div style="margin: 20px 0">
-    <mark>
-        Please note, we do not recommend using the insecure option. Rather, we recommend configuring either a public or private
-        certificate to authenticate your session before running your application.
-    </mark>
-</div>
-
-The `insecure=True` argument disables client transport security for our OTLP exporter’s connection. This will use the gRPC `insecure_channel()` 
-method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). 
-This option should never be used in production, non-sidecar deployments.
-
-If connecting to a gRPC server on the internet running gRPC over TLS, the credentials=/path/to/cert.pem argument can be used to give a path to 
-credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the 
-collector, or one of its root certificates. If no certificate is found, the gRPC method ssl_channel_credentials() will attempt to “retrieve the PEM-encoded 
-root certificates from a default location chosen by gRPC runtime” as explained in the 
-[gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
-
-The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If the address is unset, it will 
-instead try to connect to `localhost:55680`.
 
 <SubSectionSeparator />
 

--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -73,19 +73,13 @@ Next, configure the Global Tracer Provider to export to the ADOT Collector. The 
 
 The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
 
-#### Connecting to a collector running locally as a sidecar
+If the collector the application will connect to is running without TLS configured, the `insecure=True` argument is used to disable client transport security for our OTLP exporter’s connection. This will use the gRPC `insecure_channel()` method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
 
-The `insecure=True` argument disables client transport security for our OTLP exporter’s connection. This will use the gRPC `insecure_channel()`
-method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel).
-This option should never be used in production, non-sidecar deployments.
-
-#### Connecting to a collector running on the internet as a service
-
-If connecting to a gRPC server on the internet running gRPC over TLS, the `credentials=/path/to/cert.pem` argument can be used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method ssl_channel_credentials() will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+If the collector the application will connect to is running with TLS configured, the `credentials=/path/to/cert.pem` argument is used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method ssl_channel_credentials() will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
 
 #### Example TracerProvider configuration
 
-As an example where we connect to a ADOT Collector running locally deployed as a sidecar, we can setup the TracerProvider as follows:
+Connecting to an ADOT Collector running as a sidecar, we can set up the TracerProvider as follows:
 
 ```python lineNumbers=true
 # Sends generated traces in the OTLP format to an ADOT Collector running on port 55678


### PR DESCRIPTION
We want to clarify the use of `INSECURE` based on how users have set up their Collectors.

This is because words such as these get caught by Security Scanners and raise concerns that shouldn't be there as long as the Exporter is deployed correctly.

After https://github.com/open-telemetry/opentelemetry-specification/issues/1292 is addressed, we could update the refers to use the more accurate naming.