### PR TITLE
Mentioning how to setup TLS on js exporters if needed

### DIFF
--- a/src/docs/getting-started/js-sdk/metric-manual-instr.mdx
+++ b/src/docs/getting-started/js-sdk/metric-manual-instr.mdx
@@ -50,7 +50,14 @@ Once OpenTelemetry Dependencies have been imported to application, we can start 
 const metricExporter = new CollectorMetricExporter({
   serviceName: 'aws-otel-js-sample',
   logger: new ConsoleLogger(LogLevel.DEBUG),
-  url: (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) ? process.env.OTEL_EXPORTER_OTLP_ENDPOINT : "localhost:55680"
+  // port configured in the collector config, defaults to 55680
+  url: "localhost:55680"
+  // credentials only required if tls setup on collector instance
+  credentials: grpc.credentials.createSsl(
+    fs.readFileSync('./ca.crt'),
+    fs.readFileSync('./client.key'),
+    fs.readFileSync('./client.crt')
+  )
 });
 ```
 

--- a/src/docs/getting-started/js-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/js-sdk/trace-manual-instr.mdx
@@ -136,8 +136,14 @@ module.exports = (serviceName) => {
   // add OTLP exporter
   const otlpExporter = new CollectorTraceExporter({
     serviceName: serviceName,
-  // can send to any port configured in the collector config
+    // port configured in the collector config, defaults to 55680
     url: "localhost:55680"
+    // credentials only required if tls setup on collector instance
+    credentials: grpc.credentials.createSsl(
+      fs.readFileSync('./ca.crt'),
+      fs.readFileSync('./client.key'),
+      fs.readFileSync('./client.crt')
+    )
   });
   tracerProvider.addSpanProcessor(new SimpleSpanProcessor(otlpExporter));
 


### PR DESCRIPTION
Added how to setup TLS on js metrics and trace exporters to the getting started in case the user added TLS to the config of their collector instance.