### PR TITLE
Add New Relic exporter documentation

### DIFF
--- a/src/docs/partners/new-relic.mdx
+++ b/src/docs/partners/new-relic.mdx
@@ -14,25 +14,90 @@ The following configuration must be added to your existing AWS OTel Collector co
 
 1. Add the `newrelic` exporter to the list of configured exporters for traces and metrics in the _service_ section:
 
-   ```yaml
-   service:
-     pipelines:
-       traces:
-         receivers: [otlp, awsxray]
-         processors: [batch/traces]
-         exporters: [awsxray, newrelic]
-       metrics:
-         receivers: [otlp]
-         processors: [batch/metrics]
-         exporters: [awsemf, newrelic]
-   ```
+  ```yaml
+  service:
+    pipelines:
+      traces:
+        exporters: [newrelic]
+      metrics:
+        exporters: [newrelic]
+  ```
 
 2. Add the `newrelic` configuration to the _exporters_ section with your New Relic Ingest API Key:
 
-   ```yaml
-   exporters:
-     awsxray:
-     awsemf:
-     newrelic:
-       apikey: your_ingest_api_key_goes_here
-   ```
+  ```yaml
+  exporters:
+    newrelic:
+      apikey: your_ingest_api_key_goes_here
+  ```
+
+## New Relic Exporter Configuration Options
+
+#### apikey (Required)
+
+Your New Relic Insights Insert API Key.
+
+#### timeout (Optional)
+
+Amount of time spent attempting a request before abandoning and dropping data.
+
+Default is 15 seconds.
+
+#### common_attributes (Optional)
+
+Attributes to apply to all metrics sent.
+
+#### metrics_url_override (Optional)
+
+Overrides the endpoint to send metrics.
+
+Refer to New Relic
+[documentation](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-advanced-configuration#h2-change-endpoints)
+for sending data in the EU region and other common use cases.
+
+#### spans_url_override (Optional)
+
+Overrides the endpoint to send spans.
+
+Refer to New Relic
+[documentation](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-advanced-configuration#h2-change-endpoints)
+for sending data in the EU region and other common use cases.
+
+## Complete example configuration
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  newrelic:
+    apikey: your_ingest_api_key_goes_here
+    timeout: 30s
+    common_attributes:
+      server: prod-server-01
+      ready_to_rock: true
+      volume: 11
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [newrelic]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [newrelic]
+```
+
+## Additional Information
+
+For more information on the New Relic OpenTelemetry collector exporter see the
+[opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/newrelicexporter)
+repo on GitHub.

--- a/src/docs/partners/new-relic.mdx
+++ b/src/docs/partners/new-relic.mdx
@@ -1,6 +1,38 @@
----
-title: 'New Relic'
-description:
-    This is the New Relic partners page
-path: '/docs/partners/new-relic'
----
+# New Relic OpenTelemetry Collector Exporter
+
+New Relic’s OpenTelemetry Collector Exporter sends _trace_, _metric_, and _resource_ data from the AWS OpenTelemetry Collector to New Relic. This duo gives you the power of instrumenting your entire stack for complete visibility and interoperability on the New Relic One platform. Use our curated out-of-the-box experiences and flexible visualization tools to quickly gain insight into how all your apps, systems and components are performing.
+
+## Requirements
+
+1. The New Relic OpenTelemetry Collector exporter is included in the AWS OTel Collector. It requires a functioning instance of the AWS OTel Collector to operate.
+2. If you have not already done so, [create your New Relic account](https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account).
+3. Create an ingest API key using New Relic’s [API Keys UI](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
+
+## Configuration
+
+The following configuration must be added to your existing AWS OTel Collector configuration yaml file.
+
+1. Add the `newrelic` exporter to the list of configured exporters for traces and metrics in the _service_ section:
+
+   ```yaml
+   service:
+     pipelines:
+       traces:
+         receivers: [otlp, awsxray]
+         processors: [batch/traces]
+         exporters: [awsxray, newrelic]
+       metrics:
+         receivers: [otlp]
+         processors: [batch/metrics]
+         exporters: [awsemf, newrelic]
+   ```
+
+2. Add the `newrelic` configuration to the _exporters_ section with your New Relic Ingest API Key:
+
+   ```yaml
+   exporters:
+     awsxray:
+     awsemf:
+     newrelic:
+       apikey: your_ingest_api_key_goes_here
+   ```

--- a/src/docs/partners/new-relic.mdx
+++ b/src/docs/partners/new-relic.mdx
@@ -98,6 +98,12 @@ service:
 
 ## Additional Information
 
-For more information on the New Relic OpenTelemetry collector exporter see the
-[opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/newrelicexporter)
-repo on GitHub.
+Should you need assistance with New Relic products, you are in good hands with several support channels.
+
+If the issue has been confirmed as a bug or is a Feature request, please file a Github issue in the OpenTelemetry Collector contrib repository.
+
+**Support Channels**
+
+* [OpenTelemetry Documentation](https://newrelic.com/solutions/opentelemetry): Documentation for New Relic's support of OpenTelemetry
+* [OpenTelemetry Collector Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/newrelicexporter): OpenTelemetry contrib repository containing the New Relic exporter
+* [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 


### PR DESCRIPTION
Adds documentation originally drafted in issue #34 for New Relic's exporter for the AWS OTel Collector.

There is an [open question](https://github.com/aws-otel/aws-otel.github.io/issues/34#issuecomment-742172085) on the issue requesting a recommendation regarding the sample yaml config contained in this documentation. Please offer any input.