### PR TITLE
Correct NPM packages

### DIFF
--- a/src/docs/getting-started/js-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/js-sdk/trace-manual-instr.mdx
@@ -86,8 +86,8 @@ Install the AWS X-Ray components.
 
 ```bash
 $ npm install \
-  @aws-observability/propagator-aws-xray \
-  @aws-observability/id-generator-aws-xray
+  @aws/otel-aws-xray-propagator \
+  @aws/otel-aws-xray-id-generator
 ```
 
 To install a specific version, see the [release tags on the Github releases page](https://github.com/aws-observability/aws-otel-js/releases).


### PR DESCRIPTION
Current package names lead to 404s. These are the correct names:

https://www.npmjs.com/package/@aws/otel-aws-xray-propagator
https://www.npmjs.com/package/@aws/otel-aws-xray-id-generator