### PR TITLE
Inline Google Analytics key for reduced secret maintenance.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: enriikke/gatsby-gh-pages-action@v2
         env:
           GH_API_KEY: ${{ secrets.gh }}
-          GA_KEY: ${{ secrets.ga }}
         with:
           access-token: ${{ secrets.demo }}
           deploy-branch: gh-pages

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: process.env.GA_KEY || "none",
+        trackingId: 'UA-180925204-1',
       }
     },
     {


### PR DESCRIPTION
A GA id is public by definition, which is how I could find it so easily from the home page :) There's no need to obfuscate the fact that it's public by putting it in a secret and possibly having some false sense of security.