### PR TITLE
[partners/datadog]: update resource links to incl datadog docs

### DIFF
--- a/src/docs/partners/datadog.mdx
+++ b/src/docs/partners/datadog.mdx
@@ -127,7 +127,7 @@ Supply the relative path to this configuration file when you start the collector
 
 ## Resources
 
-For additional information about the Datadog exporter, see the [`open-telemetry` Github repo](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter).
+For additional information about the Datadog exporter and environment specific onboarding instructions, visit the [Datadog OpenTelemetry Collector](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter) documentation or the [`open-telemetry` Github repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter).
 
 ## Support
 

--- a/src/docs/partners/dynatrace.mdx
+++ b/src/docs/partners/dynatrace.mdx
@@ -15,7 +15,7 @@ Given an environment ID `abc12345` on Dynatrace SaaS, for example, the metrics i
 
 The requests sent to Dynatrace are authenticated using an API token. Creating an API token for your Dynatrace environment is described in the [Dynatrace API documentation](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/). The only access scope required for exporting metrics is the **Ingest metrics** (`metrics.ingest`) scope listed in the **API v2** section. It is recommended to limit the token's scope to only that one.
 
-## COnfiguring the Dynatrace Metrics Exporter
+## Configuring the Dynatrace Metrics Exporter
 
 To enable the Dynatrace metrics exporter, write the name under exporter section in the OpenTelemetry config file (`local/config.yaml`) and add the `dynatrace` exporter to your metrics pipeline.
 


### PR DESCRIPTION
### Summary

Hello friends, this PR is a small update to the `partners/datadog` section to include a link to Datadog's documentation page on OpenTelemetry, which includes more detailed instructions on environment specific setup for Docker and K8s environments. Additionally I noticed some small typos in other partner docs that I cleaned up.

### Notes

I am an employee of Datadog but please let me know if additional confirmation from someone on the ddog side is needed here.
