### PR TITLE
update advanced prometheus receiver configuration

### DIFF
--- a/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
+++ b/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
@@ -462,6 +462,45 @@ roleRef:
 ---
 ```
 
+To scrape Node or cAdvisor metrics, we need to provide the service account access to `nodes/metrics`. As an example, 
+the following ClusterRole and ClusterRoleBinding should work for Pod, Node, Service, and cAdvisor metrics. 
+
+```lineNumbers=true 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prom-admin
+rules:
+- apiGroups: [""]
+  resources:
+    - nodes
+    - nodes/proxy
+    - nodes/metrics
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prom-rbac
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: otelcol
+roleRef:
+  kind: ClusterRole
+  name: prom-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+```
+
 <SectionSeparator />
 
 ## AWS Prometheus Remote Write Exporter Configurations


### PR DESCRIPTION
**Description:**
Our current prometheus receiver advanced configuration does not work for collecting cAdvisor metrics using kubernetes service discovery. We need to provide the sercice account access to `nodes/metrics` resources to enable it which is missing in our doc. This PR update the doc with tested configuration. 