### PR TITLE
Update manual instrumentation docs to 1.0.1

### DIFF
--- a/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
@@ -36,7 +36,7 @@ First, include the OpenTelemetry SDK as a compile dependency.
 ##### For Gradle:
 ```java lineNumbers=true
 dependencies {
-    implementation('io.opentelemetry:opentelemetry-sdk:0.17.0')
+    implementation('io.opentelemetry:opentelemetry-sdk:1.0.1')
 }
 ```
 
@@ -46,7 +46,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk</artifactId>
-    <version>0.17.0</version>
+    <version>1.0.1</version>
   </dependency>
 </dependencies>
 ```
@@ -60,7 +60,7 @@ automatically initialize tracing, add a dependency on the starter.
 
 ##### For Gradle:
 ```java
-implementation 'io.opentelemetry.instrumentation:opentelemetry-otlp-exporter-starter:0.17.0-alpha'
+implementation 'io.opentelemetry.instrumentation:opentelemetry-otlp-exporter-starter:1.0.1-alpha'
 ```
 
 ##### For Maven:
@@ -69,7 +69,7 @@ implementation 'io.opentelemetry.instrumentation:opentelemetry-otlp-exporter-sta
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-otlp-exporter-starter</artifactId>
-    <version>0.17.0-alpha</version>
+    <version>1.0.1-alpha</version>
   </dependency>
 </dependencies>
 ```
@@ -96,7 +96,7 @@ the AWS SDK, add a dependency on the library instrumentation for the AWS SDK.
 
 ##### For Gradle:
 ```java
-implementation 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2:0.17.0-alpha'
+implementation 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2:1.0.1-alpha'
 ```
 
 ##### For Maven:
@@ -105,7 +105,7 @@ implementation 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2:0.17.
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
-    <version>0.17.0-alpha</version>
+    <version>1.0.1-alpha</version>
   </dependency>
 </dependencies>
 ```
@@ -133,7 +133,7 @@ Add a dependency on the AWS extensions to the OpenTelemetry SDK
 
 
 ```java
-implementation 'io.opentelemetry:opentelemetry-sdk-extension-aws:0.17.0'
+implementation 'io.opentelemetry:opentelemetry-sdk-extension-aws:1.0.1'
 ```
 
 ##### For Maven:
@@ -142,7 +142,7 @@ implementation 'io.opentelemetry:opentelemetry-sdk-extension-aws:0.17.0'
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk-extension-aws</artifactId>
-    <version>0.17.0</version>
+    <version>1.0.1</version>
   </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
Was thinking of trying to extract a variable for version number but not this time since oldish version of Gatsby isn't starting up on my computer's nodejs