### PR TITLE
Update aoc doc link after folder structures are updated

### DIFF
--- a/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
+++ b/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
@@ -288,7 +288,7 @@ service. We can use the [Blackbox Exporter provided by Prometheus](https://githu
 #### Prerequisite
 
 To use the blackbox exporter, ** we can deploy the configurations 
-[here](https://github.com/aws-observability/aws-otel-collector/blob/main/examples/eks/prometheus-pipeline/prometheus-blackbox-exporter.yaml).
+[here](https://github.com/aws-observability/aws-otel-collector/blob/main/examples/eks/aws-prometheus/prometheus-blackbox-exporter.yaml).
 
 Using the name of the Blackbox Exporter service and the exposed port (9115), we can access the probed metrics. This is done by 
 replacing the `__address__`. If we do not want to probe all services, we can specify a list of target addresses to probe in the `static_configs` 

--- a/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
@@ -112,7 +112,7 @@ Next, push this image to a remote repository on either ECR or Dockerhub so that 
 
 ## Demonstration 1: ECS Powered by Fargate
 
-1. [Download the ECS Fargate AMP task definition template from Github.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/prometheus-pipeline/ecs-fargate-task-def.json) This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
+1. [Download the ECS Fargate AMP task definition template from Github.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-fargate-task-def.json) This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
 2. Fill the following parameters in the task definition templates:
     * `region` - the region the data will be sent to
     * `ecsTaskRoleArn` - AWSOTTaskRole ARN created in the previous section
@@ -120,7 +120,7 @@ Next, push this image to a remote repository on either ECR or Dockerhub so that 
     * `sampleAppImage` - the image to the Prometheus sample app we created above
 3. Follow the [ECS task definition setup instructions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html), and use the “Fargate Launch Type” instructions step 1 to create a task definition using the given template.
     * Be sure to verify all of the fields match the template
-4. [Download the custom ADOT Collector configuration.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/prometheus-pipeline/ecs-fargate-adot-config.yaml) This configuration uses the Prometheus Receiver to scrape from a static target. Notice that our sample app is automatically deployed on port 8080. 
+4. [Download the custom ADOT Collector configuration.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-fargate-adot-config.yaml) This configuration uses the Prometheus Receiver to scrape from a static target. Notice that our sample app is automatically deployed on port 8080. 
     * Fill the following parameters in the ADOT Collector configuration:
       * `region` - the region the data will be sent to
       * `endpoint` - the AMP remote_write endpoint which we will export data to
@@ -135,7 +135,7 @@ Note that you must have a cluster created with an EC2 instance available. We cho
 
 <img src={createClusterECSImg} alt="Diagram" style="margin: 30px 0;" />
 
-1. [Download the ECS EC2 AMP task definition template from Github](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/prometheus-pipeline/ecs-ec2-task-def.json). This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
+1. [Download the ECS EC2 AMP task definition template from Github](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-ec2-task-def.json). This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
 2. Fill the following parameters in the task definition templates:
     * `region` - the region the data will be sent to
     * `ecsTaskRoleArn` - AWSOTTaskRole ARN created in the previous section
@@ -143,7 +143,7 @@ Note that you must have a cluster created with an EC2 instance available. We cho
     * `sampleAppImage` - the image to the Prometheus sample app we created above
 3. Follow the [ECS task definition setup instructions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html), and use the “EC2 Launch Type” instructions step 1 to create a task definition using the given template.
     * Be sure to verify all of the fields match the template
-4. [Download the custom ADOT Collector configuration](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/prometheus-pipeline/ecs-ec2-adot-config.yaml). This configuration uses the Prometheus Receiver to scrape from a static target using an environment variable.
+4. [Download the custom ADOT Collector configuration](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-ec2-adot-config.yaml). This configuration uses the Prometheus Receiver to scrape from a static target using an environment variable.
     * Fill the following parameters in the ADOT Collector configuration:
         * `region` - the region the data will be sent to
         * `endpoint` - the AMP remote_write endpoint which we will export data to

--- a/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
@@ -112,7 +112,7 @@ Next, push this image to a remote repository on either ECR or Dockerhub so that 
 
 ## Demonstration 1: ECS Powered by Fargate
 
-1. [Download the ECS Fargate AMP task definition template from Github.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-fargate-task-def.json) This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
+1. [Download the ECS Fargate AMP task definition template from GitHub.](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-fargate-task-def.json) This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
 2. Fill the following parameters in the task definition templates:
     * `region` - the region the data will be sent to
     * `ecsTaskRoleArn` - AWSOTTaskRole ARN created in the previous section
@@ -135,7 +135,7 @@ Note that you must have a cluster created with an EC2 instance available. We cho
 
 <img src={createClusterECSImg} alt="Diagram" style="margin: 30px 0;" />
 
-1. [Download the ECS EC2 AMP task definition template from Github](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-ec2-task-def.json). This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
+1. [Download the ECS EC2 AMP task definition template from GitHub](https://github.com/aws-observability/aws-otel-collector/tree/main/examples/ecs/aws-prometheus/ecs-ec2-task-def.json). This definition specifies a Prometheus sample app and an ADOT Collector instance. If you would like to learn more about the sample app, please visit [here](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus).
 2. Fill the following parameters in the task definition templates:
     * `region` - the region the data will be sent to
     * `ecsTaskRoleArn` - AWSOTTaskRole ARN created in the previous section

--- a/src/docs/setup/ecs/task-definition-for-ecs-ec2.mdx
+++ b/src/docs/setup/ecs/task-definition-for-ecs-ec2.mdx
@@ -14,7 +14,7 @@ In this tutorial, we will demonstrate how to create an ECS Task Definition for E
 <SectionSeparator />
 
 ### Setup for ECS EC2
-1. [Download the ECS EC2 task definition template](https://github.com/aws-observability/aws-otel-collector/blob/master/examples/ecs/ecs-ec2-sidecar.json) from GitHub.
+1. [Download the ECS EC2 task definition template](https://github.com/aws-observability/aws-otel-collector/blob/master/examples/ecs/aws-cloudwatch/ecs-ec2-sidecar.json) from GitHub.
 2. Fill the following parameters in the task definition templates:
     * `{{region}}` - the region the data will be sent to
     * `{{ecsTaskRoleArn}}` - **AWSOTTaskRole** ARN created in the previous section

--- a/src/docs/setup/ecs/task-definition-for-ecs-fargate.mdx
+++ b/src/docs/setup/ecs/task-definition-for-ecs-fargate.mdx
@@ -14,7 +14,7 @@ In this tutorial, we will demonstrate how to create an ECS Task Definition for F
 <SectionSeparator />
 
 ### Setup for ECS Fargate
-1. [Download the ECS Fargate task definition template](https://github.com/aws-observability/aws-otel-collector/blob/master/examples/ecs/ecs-fargate-sidecar.json) from Github.
+1. [Download the ECS Fargate task definition template](https://github.com/aws-observability/aws-otel-collector/blob/master/examples/ecs/aws-cloudwatch/ecs-fargate-sidecar.json) from Github.
 2. Fill the following parameters in the task definition templates:
     * `{{region}}` - the region the data will be sent to
     * `{{ecsTaskRoleArn}}` - **AWSOTTaskRole** ARN created in the previous section

--- a/src/docs/setup/eks.mdx
+++ b/src/docs/setup/eks.mdx
@@ -45,12 +45,12 @@ trace data for the application.
 kubectl create namespace aws-otel-eks
 ```
 2. An example configuration template can be
-found [under examples in the AWC OTel Collector GitHub](https://github.com/aws-observability/aws-otel-collector/blob/main/examples/eks/eks-sidecar.yaml).
+found [under examples in the AWC OTel Collector GitHub](https://github.com/aws-observability/aws-otel-collector/blob/main/examples/eks/aws-cloudwatch/otel-sidecar.yaml).
 Replace `{{aws-otelImage}}` with the name of the AWS OTel Collector Docker image you built
 (For example, `aottestbed/awscollector:v0.1.12`), and `{{region}}` with the name of the Region where the logs are published (For example, `us-west-2`).
 3. Deploy the application.
 ```
-kubectl apply -f https://raw.githubusercontent.com/aws-observability/aws-otel-collector/main/examples/eks/eks-sidecar.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws-observability/aws-otel-collector/main/examples/eks/aws-cloudwatch/otel-sidecar.yaml
 ```
 4. View the resources in the `aws-otel-eks` namespace.
 ```


### PR DESCRIPTION
**Why do we need it?**
This is a follow-up PR of https://github.com/aws-observability/aws-otel-collector/pull/453. We updated the folder structure of `/examples` and renamed files in `/deployment-template/eks` to have the docs ordered in a more reasonable way. 

This PR fixes the links to the files that are affected by the renaming changes in aoc.