### PR TITLE
add ADOT lambda support landing page

### DIFF
--- a/src/config/sideBarData.js
+++ b/src/config/sideBarData.js
@@ -52,7 +52,7 @@ export const sideBarData = [
         {label: "JavaScript", link: "/docs/getting-started/javascript-sdk"},
         {label: "Python", link: "/docs/getting-started/python-sdk"},
         {label: ".NET", link: "/docs/getting-started/dotnet-sdk"},
-        {label: "Lambda for Python", link: "/docs/getting-started/lambda"},
+        {label: "Lambda", link: "/docs/getting-started/lambda"},
         {label: "Prometheus (AMP)", link: "/docs/getting-started/prometheus-remote-write-exporter"},
         {label: "Prometheus Configurations", link: "/docs/getting-started/advanced-prometheus-remote-write-configurations"},
         {label: "CloudWatch Metrics", link: "/docs/getting-started/cloudwatch-metrics"},

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -11,7 +11,7 @@ path: '/docs/getting-started/lambda'
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
 
-The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
+The AWS Distro for OpenTelemetry now supports AWS managed Lambda layers.
     ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
     instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
     for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -21,7 +21,7 @@ The AWS Distro for OpenTelemetry now supports AWS managed Lambda layers.
 
 ## Getting Started with AWS Lambda layers
 
-* [ADOT Lambda Layer for Java SDK and ADOT Collector](/docs/getting-started/lambda/lambda-java)
+* [AWS managed Lambda layer for ADOT - Java SDK and ADOT Collector](/docs/getting-started/lambda/lambda-java)
 * [ADOT Lambda Layer for Java Auto Agent and ADOT Collector](/docs/getting-started/lambda/lambda-java-auto-instr)
 * [ADOT Lambda Layer for JavaScript SDK and ADOT Collector](/docs/getting-started/lambda/lambda-js)
 * [ADOT Lambda Layer for Python SDK and ADOT Collector](/docs/getting-started/lambda/lambda-python)

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -1,10 +1,11 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Python'
+title: 'AWS Distro for OpenTelemetry Lambda'
 description:
-    The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides a plug and play user experience by automatically 
-    instrumenting a Lambda function, by packaging OpenTelemetry Python together with an out-of-the-box configuration for AWS Lambda and 
-    AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code. Currently, this layer is 
-    only for Python Lambda functions.
+    The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
+    ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
+    instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
+    for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry
+    for their Lambda function without changing code.
 path: '/docs/getting-started/lambda'
 ---
 
@@ -12,96 +13,76 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
 
 
-The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides a plug and play user experience by automatically 
-instrumenting a Lambda function, by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) together 
-with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function 
-without changing code. Currently, this layer is only for Python Lambda functions.
+The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
+    ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
+    instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
+    for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry
+    for their Lambda function without changing code.
 
 <SectionSeparator />
 
-## Requirements
+## Getting Started with AWS Lambda layers
 
-The Lambda layer supports Python 3.8 Lambda runtimes. For more information about supported Python versions, see the 
-[OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python/blob/master/README.md#supported-runtimes) and the [package on PyPi](https://pypi.org/project/opentelemetry-api/).
+* [ADOT Lambda Layer for Java SDK and ADOT Collector](/docs/getting-started/java-sdk/metric-manual-instr)
+* [ADOT Lambda Layer for Java Auto Agent and ADOT Collector](/docs/getting-started/java-sdk/trace-auto-instr)
+* [ADOT Lambda Layer for JavaScript SDK and ADOT Collector](/docs/getting-started/java-sdk/trace-manual-instr)
+* [ADOT Lambda Layer for Python SDK and ADOT Collector](/docs/getting-started/lambda/lambda-python)
 
-To build the Lambda Layer, install the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)and 
-[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) tools.
+## Manual Steps for Private Lambda Layers
+See the documentation on the [OpenTelemetry Lambda repository](https://github.com/open-telemetry/opentelemetry-lambda/).
 
-Configure the AWS CLI using [aws configure]. Provide your AWS credentials, 
-[with administrator permissions](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html#serverless-sam-cli-install-mac-iam-permissions), 
-and your chosen default Region.
+## Custom configuration for the ADOT Collector on Lambda
+The ADOT Lambda layers combines both OpenTelemetry and the ADOT Collector.
+The configuration of the ADOT Collector follows the OpenTelemetry standard.
+By default, the ADOT Lambda layer uses [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
+which exports telemetry data to AWS X-Ray.
 
-Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published. Make sure to publish 
-the layer in the same Regions as your Lambda functions.
+To enable debugging, you can use the configuration file to set log level to debug. See the example below.
 
-<SubSectionSeparator />
+To customize the collector configuration, add a configuration yaml file to your function code.
+Once the file has been deployed with a Lambda function, create an environment variable on your Lambda
+function `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` and set it to `/var/task/*<path/<to>/<filename>*`.
+This will tell the extension where to find the collector configuration.
 
-### Build the Lambda Layer 
+Here is a sample configuration file, collector.yaml in the root directory:
+```yaml
+#collector.yaml in the root directory
+#Set an environemnt variable 'OPENTELEMETRY_COLLECTOR_CONFIG_FILE' to '/var/task/<path/<to>/<file>'
 
-In this section, we will pull, build, and publish a reusable Lambda layer for use with Python Lambda Functions. This includes a reduced version of the 
-[AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector), which runs as a Lambda extension.
+receivers:
+  otlp:
+    protocols:
+      grpc:
 
-1. Download a local copy of the [aws-otel-lambda repository from Github](https://github.com/aws-observability/aws-otel-lambda/archive/main.zip).
-2. Unzip the downloaded repository and run the `run.sh` script from the sample-apps directory. This publishes the layer into your personal account.
-    ```
-    cd sample-apps/python-lambda && clear
-    ```
+exporters:
+  logging:
+    loglevel: debug
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:55681
 
-Tips:
-* To publish the layer to other Regions, use  `-r`, for example `./run.sh -r us-west-2`
-* After the layer is published, it can be reused across multiple Lambda functions. You don’t have to republish the layer, unless you would like to upgrade the layer to the latest version.
-
-You will need the layer Amazon Resource Name (ARN) to add it to your Lambda function. To get the ARN from another region, use `-r <region>` as shown previously.
-
+#enables output for traces to xray
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, xray]
 ```
- # Get the Lambda layer ARN
- ./run.sh -l 
+You can set this via the Lambda console, or via the AWS CLI.
+```
+aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
+```
+You can configure environment variables via CloudFormation template as well:
+```yaml
+Function:
+  Type: AWS::Serverless::Function
+  Properties:
+    ...
+    Environment:
+      Variables:
+        OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yaml
 ```
 
-<SubSectionSeparator />
-
-### Enable auto-instrumentation for your Lambda function
-
-To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
-
-1. Open the Lambda function you intend to instrument in the in AWS console. 
-2. In the **Layers in Designer** section, choose **Add a layer**.
-3.  Under **specify an ARN**, paste the layer ARN, and then choose **Add**.
-4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER = /opt/python/adot-instrument` to your Lambda function. This enable auto-instumentations.
-5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
-
-Tips:
-
-* By default, the layer is configured to 
-[export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23), 
-make sure your Lambda role has the required X-Ray permissions.
-
-<SubSectionSeparator />
-
-### Remove OpenTelemetry from your Lambda function
-
-To disable OpenTelemetry for you Lambda function, remove the Lambda layer, remove the environment 
-variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
-
-<SectionSeparator />
-
-## Configuration 
-
-The ADOT Python Lambda layer combines both OpenTelemetry Python and the ADOT Collector. The configuration of the ADOT Collector follows the OpenTelemetry standard.
-
-By default, the ADOT Lambda layer uses [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/extensions/aoc-extension/config.yaml), 
-which exports telemetry data to AWS X-Ray and AWS CloudWatch.
-
-For debugging, you can turn on the logging exporter in the Collector by adding the environment variable `ADOT_DEBUG=true` in the Lambda function.
-
-To fully customize the Collector config, there are two options:
-* Bring customized config file (and ca/cert/key files) into the Lambda function by the Lambda layer, then set the Collector config by environment variable `ADOT_CONFIG=<your config file path>`
-* Add the environment variable `ADOT_CONFIG_CONTENT=<Full content of your config file>`
-
-For more information about ADOT Collector configuration like adding ca/cert/key files, see the Github 
-[README.md](https://github.com/aws-observability/aws-otel-lambda/blob/main/extensions/sample-aoc-config/README.md).
-
-
-
-
-
+For more information about ADOT Collector configuration,
+such as adding ca/cert/key files, see the Github [README.md](https://github.com/aws-observability/aws-otel-lambda/blob/main/extensions/sample-aoc-config/README.md).

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -14,7 +14,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 The AWS Distro for OpenTelemetry now supports AWS managed Lambda layers.
      AWS managed Lambda layers for ADOT (ADOT Lambda) provides a plug and play user experience by automatically
     instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
-    for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry
+    for AWS Lambda and AWS X-Ray in an easy to setup layer. Users can enable and disable OpenTelemetry
     for their Lambda function without changing code.
 
 <SectionSeparator />

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -12,7 +12,7 @@ path: '/docs/getting-started/lambda'
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
 
 The AWS Distro for OpenTelemetry now supports AWS managed Lambda layers.
-    ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
+     AWS managed Lambda layers for ADOT (ADOT Lambda) provides a plug and play user experience by automatically
     instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
     for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry
     for their Lambda function without changing code.

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'AWS Distro for OpenTelemetry Lambda'
 description:
-    The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
+    The AWS Distro for OpenTelemetry now supports AWS managed Lambda layers.
     ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
     instrumenting a Lambda function, by packaging OpenTelemetry together with an out-of-the-box configuration
     for AWS Lambda and AWS X-Ray in an easy to setup  layer. Users can enable and disable OpenTelemetry

--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -10,8 +10,6 @@ path: '/docs/getting-started/lambda'
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
-
 
 The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
     ADOT Lambda layers for AWS Lambda provides a plug and play user experience by automatically
@@ -23,9 +21,9 @@ The AWS Distro for OpenTelemetry now supports AWS Lambda layers.
 
 ## Getting Started with AWS Lambda layers
 
-* [ADOT Lambda Layer for Java SDK and ADOT Collector](/docs/getting-started/java-sdk/metric-manual-instr)
-* [ADOT Lambda Layer for Java Auto Agent and ADOT Collector](/docs/getting-started/java-sdk/trace-auto-instr)
-* [ADOT Lambda Layer for JavaScript SDK and ADOT Collector](/docs/getting-started/java-sdk/trace-manual-instr)
+* [ADOT Lambda Layer for Java SDK and ADOT Collector](/docs/getting-started/lambda/lambda-java)
+* [ADOT Lambda Layer for Java Auto Agent and ADOT Collector](/docs/getting-started/lambda/lambda-java-auto-instr)
+* [ADOT Lambda Layer for JavaScript SDK and ADOT Collector](/docs/getting-started/lambda/lambda-js)
 * [ADOT Lambda Layer for Python SDK and ADOT Collector](/docs/getting-started/lambda/lambda-python)
 
 ## Manual Steps for Private Lambda Layers

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -62,7 +62,7 @@ To disable OpenTelemetry for your Lambda function, remove the Lambda layer, remo
 
 ## Configuration
 
-The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The ADOT Java Auto-instrumentation Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml), which exports telemetry data to AWS X-Ray. To customize the Collector config, see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda).

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -1,0 +1,74 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Support For Java (Auto-instrumentation Agent)'
+description:
+    The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for Java provides a plug-and-play user experience by automatically instrumenting a AWS Lambda function, by packaging either the ADOT Java Agent (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr) or OpenTelemetry Java SDK (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+    With the ADOT Lambda Layer for Java Auto Agent, all supported libraries are automatically instrumented, with no additional configurations needed.
+path: '/docs/getting-started/lambda/lambda-java-auto-instr'
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
+
+The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides
+a plug and play user experience by automatically instrumenting a Lambda function,
+by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python)
+together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+
+<SectionSeparator />
+
+## Requirements
+
+The Lambda layer supports Java 8 and 11 Lambda runtimes. For more information about supported Java versions,
+see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).
+
+Note: ADOT Lambda Layer for Java Auto Agent - Automatic instrumentation has a notable
+impact on startup time on AWS Lambda and you will generally need to use this along with provisioned
+concurrency and warmup requests to serve production requests without causing timeouts on initial requests while it initializes.
+
+### Add the ARN of the Lambda Layer
+
+In this section, we consume the Lambda layer for use with Java Lambda Functions. This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector), which runs as a Lambda extension.
+
+Note: Lambda layers are a regionalized resource, meaning that they can only be used in the region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
+
+Find the supported regions and ARN in the table below for the ARNs to consume.
+
+|Supported   Regions |Lambda layer ARN format| Contents |
+|---------------------|-------------------------|----------|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-1-0:1 | Contains ADOT Java Auto Agent v1.1.0 (https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.1.0) <br/><br/> Contains the ADOT Collector for Lambda  v0.9.1 (https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1) |
+
+### Enable auto-instrumentation for your Lambda function
+
+To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
+
+1. Open the Lambda function you intend to instrument in the in AWS console. 
+2. In the *Layers in Designer* section, choose *Add a layer*.
+3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+4. Add the environment variable AWS_LAMBDA_EXEC_WRAPPER and set to one of the following options:
+    1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
+5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
+
+Tips:
+
+* By default, the layer is configured to export traces to [AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23), make sure your Lambda role has the required AWS X-Ray permissions. See more on AWS X-Ray permissions for AWS Lambda, see the AWS Lambda documentation (https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+
+### Remove OpenTelemetry from your Lambda function
+
+To disable OpenTelemetry for your Lambda function, remove the Lambda layer, remove the environment variable AWS_LAMBDA_EXEC_WRAPPER, and disable active tracing, as explained in the section above.
+
+<SectionSeparator />
+
+## Configuration
+
+The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The configuration of the ADOT Collector follows the OpenTelemetry standard.
+
+By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml), which exports telemetry data to AWS X-Ray. To customize the Collector config, see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda).
+
+
+<SectionSeparator />
+
+## Additional Instrumentation
+
+For additional instrumentation, see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -36,7 +36,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-1-0:1 | Contains ADOT Java Auto Agent v1.1.0 (https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.1.0) <br/><br/> Contains the ADOT Collector for Lambda  v0.9.1 (https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-1-0:1 | Contains [ADOT Java Auto Agent v1.1.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.1.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.9.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1) |
 
 ### Enable auto-instrumentation for your Lambda function
 
@@ -51,7 +51,8 @@ To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to 
 
 Tips:
 
-* By default, the layer is configured to export traces to [AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23), make sure your Lambda role has the required AWS X-Ray permissions. See more on AWS X-Ray permissions for AWS Lambda, see the AWS Lambda documentation (https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+* By default, the layer is configured to export traces to AWS X-Ray. Make sure your Lambda role has the required AWS X-Ray permissions.
+For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Remove OpenTelemetry from your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -2,7 +2,7 @@
 title: 'AWS Distro for OpenTelemetry Lambda Support For Java (Auto-instrumentation Agent)'
 description:
     The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for Java provides a plug-and-play user experience by automatically instrumenting a AWS Lambda function, by packaging either the ADOT Java Agent (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr) or OpenTelemetry Java SDK (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-    With the ADOT Lambda Layer for Java Auto Agent, all supported libraries are automatically instrumented, with no additional configurations needed.
+    With the ADOT Lambda Layer for Java Auto-instrumentation Agent, all supported libraries are automatically instrumented, with no additional configurations needed.
 path: '/docs/getting-started/lambda/lambda-java-auto-instr'
 ---
 
@@ -22,7 +22,7 @@ Users can enable and disable OpenTelemetry for their Lambda function without cha
 The Lambda layer supports Java 8 and 11 Lambda runtimes. For more information about supported Java versions,
 see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).
 
-Note: ADOT Lambda Layer for Java Auto Agent - Automatic instrumentation has a notable
+Note: ADOT Lambda Layer for Java Auto-Instrumentation Agent - Automatic instrumentation has a notable
 impact on startup time on AWS Lambda and you will generally need to use this along with provisioned
 concurrency and warmup requests to serve production requests without causing timeouts on initial requests while it initializes.
 
@@ -36,7 +36,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-1-0:1 | Contains [ADOT Java Auto Agent v1.1.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.1.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.9.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-1-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.1.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.1.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.9.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -1,0 +1,109 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Support For Java'
+description:
+    The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for Java provides
+     a plug-and-play user experience by wrapping an AWS Lambda function,
+     and by packaging the [OpenTelemetry Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)
+     together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+     Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+     With the ADOT Lambda Layer for Java, the wrapper has built-in support for instrumenting the AWS SDK automatically.
+     For additional instrumenting functionality, see the documentation on [auto-instrumentation for traces](https://quip-amazon.com/CLFnA0caodZV/AWS-Distro-for-OpenTelemetry-Lambda-Support-For-Java-Auto-instrumentation-Agent).
+
+path: '/docs/getting-started/lambda/lambda-java'
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for Java provides
+     a plug-and-play user experience by wrapping an AWS Lambda function,
+     and by packaging the [OpenTelemetry Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)
+     together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+     Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+
+With the ADOT Lambda Layer for Java, the wrapper has built-in support for instrumenting the AWS SDK automatically.
+     For additional instrumenting functionality, see the documentation on [auto-instrumentation for traces](https://quip-amazon.com/CLFnA0caodZV/AWS-Distro-for-OpenTelemetry-Lambda-Support-For-Java-Auto-instrumentation-Agent).
+
+
+<SectionSeparator />
+
+## Requirements
+
+The Lambda layer supports Java 8 and 11 Lambda runtimes. For more information about supported Java versions,
+see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).
+
+### Known issues
+
+ADOT Lambda Layer for Java Auto Agent - Automatic instrumentation has a notable impact on startup time on
+AWS Lambda and you will generally need to use this along with provisioned concurrency
+and warmup requests to serve production requests without causing timeouts on initial requests while it initializes.
+
+### Add the ARN of the Lambda Layer
+
+In this section, we consume the Lambda layer for use with Node.JS Lambda Functions.
+ This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
+  which runs as a Lambda extension.
+
+Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published.
+ Make sure to use the layer in the same region as your Lambda functions.
+
+Find the supported regions and ARN in the table below for the ARNs to consume.
+
+|Supported   Regions |Lambda layer ARN format| Contents |
+|---------------------|-------------------------|----------|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-1-0:1 | Contains [OpenTelemetry for Java v01.1.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.1.0) with [Java Instrumentatino v1.1.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.1.0)|
+
+
+### Enable auto-instrumentation for your Lambda function
+To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
+
+1. Open the Lambda function you intend to instrument in the in AWS console.
+2. In the *Layers in Designer* section, choose *Add a layer*.
+3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to one of the following options:
+    1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
+    2. `/opt/otel-proxy-handler` - for wrapping regular handlers (implementing RequestHandler) proxied through API Gateway, enabling HTTP context propagation
+    3. `/opt/otel-stream-handler` - for wrapping streaming handlers (implementing RequestStreamHandler), enabling HTTP context propagation for HTTP requests
+5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
+
+
+
+Tips:
+
+* By default, the layer is configured to [export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23),
+ make sure your Lambda role has the required AWS X-Ray permissions.
+  See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+
+### Enable additional instrumentation
+
+[AWS SDK instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/aws-sdk/aws-sdk-2.2/library)
+is included and loaded automatically if you use the AWS SDK.
+
+However, for any other library, you will need to include the corresponding library instrumentation
+from the [OpenTelemetry instrumentation repository](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
+ and modify your code to initialize it in your function. See the README.MD file for each library for additional information.
+
+You can see an example with OKHttp in the [OpenTelemetry Lambda sample application](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/java#sample-applications).
+
+### Remove OpenTelemetry from your Lambda function
+
+To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
+remove the environment `variable AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
+
+
+<SectionSeparator />
+
+## Configuration
+
+The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The configuration of the ADOT Collector follows the OpenTelemetry standard.
+
+By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
+ which exports telemetry data to AWS X-Ray. To customize the Collector config,
+ see the [page](/docs/getting-started/lambda)
+
+
+<SectionSeparator />
+
+## Additional Instrumentation
+
+For additional instrumentation, see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ and warmup requests to serve production requests without causing timeouts on ini
 
 ### Add the ARN of the Lambda Layer
 
-In this section, we consume the Lambda layer for use with Node.JS Lambda Functions.
+In this section, we consume the Lambda layer for use with Java Lambda Functions.
  This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
   which runs as a Lambda extension.
 
@@ -50,7 +50,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-1-0:1 | Contains [OpenTelemetry for Java v01.1.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.1.0) with [Java Instrumentatino v1.1.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.1.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-1-0:1 | Contains [OpenTelemetry for Java v01.1.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.1.0) with [Java Instrumentation v1.1.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.1.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function
@@ -69,8 +69,8 @@ To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to 
 
 Tips:
 
-* By default, the layer is configured to [export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23),
- make sure your Lambda role has the required AWS X-Ray permissions.
+* By default, the layer is configured to export traces to AWS X-Ray.
+ Make sure your Lambda role has the required AWS X-Ray permissions.
   See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Enable additional instrumentation
@@ -99,7 +99,7 @@ The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
  which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [page](/docs/getting-started/lambda)
+ see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda)
 
 
 <SectionSeparator />

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -93,7 +93,7 @@ remove the environment `variable AWS_LAMBDA_EXEC_WRAPPER`, and disable active tr
 
 ## Configuration
 
-The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The AWS Lambda layer for ADOT Java combines both the ADOT Java SDK and the ADOT Collector.
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -33,7 +33,6 @@ see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/ope
 
 ### Known issues
 
-ADOT Lambda Layer for Java Auto Agent - Automatic instrumentation has a notable impact on startup time on
 AWS Lambda and you will generally need to use this along with provisioned concurrency
 and warmup requests to serve production requests without causing timeouts on initial requests while it initializes.
 

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -1,20 +1,19 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Python'
+title: 'AWS Distro for OpenTelemetry Lambda Support For JavaScript'
 description:
     The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides
     a plug and play user experience by automatically instrumenting a Lambda function,
-    by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python)
+    by packaging [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
     together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
     Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-path: '/docs/getting-started/lambda/lambda-python'
+path: '/docs/getting-started/lambda/lambda-js'
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
 
 The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides
 a plug and play user experience by automatically instrumenting a Lambda function,
-by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python)
+by packaging [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
 Users can enable and disable OpenTelemetry for their Lambda function without changing code.
 
@@ -22,13 +21,12 @@ Users can enable and disable OpenTelemetry for their Lambda function without cha
 
 ## Requirements
 
-The Lambda layer supports Python 3.8 Lambda runtimes. For more information about supported Python versions,
-see the [OpenTelemetry Python documentation](https://github.com/open-telemetry/opentelemetry-python/blob/master/README.md#supported-runtimes)
-and the package on [PyPi](https://pypi.org/project/opentelemetry-api/).
+The Lambda layer supports Node.JS v10+ Lambda runtimes. For more information about supported JavaScript and Node.JS versions,
+ see the [OpenTelemetry JavaScript documentation](https://github.com/open-telemetry/opentelemetry-js).
 
 ### Add the ARN of the Lambda Layer
 
-In this section, we consume the Lambda layer for use with Python Lambda Functions.
+In this section, we consume the Lambda layer for use with Node.JS Lambda Functions.
  This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
   which runs as a Lambda extension.
 
@@ -39,7 +37,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-1-0:1 | Contains [OpenTelemetry for Python v1.1.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.1.0) with [Contrib v0.20b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.20b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.9.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-18-0:1 | Contains [OpenTelemetry for JavaScript v0.18.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.18.0) with [Contrib v0.20b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.20b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.9.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.9.1)|
 
 
 ### Enable auto-instrumentation for your Lambda function
@@ -48,7 +46,7 @@ To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to 
 1. Open the Lambda function you intend to instrument in the in AWS console.
 2. In the *Layers in Designer* section, choose *Add a layer*.
 3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
-4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to `/opt/otel-instrument`.
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to `/opt/otel-handler`.
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 
 Tips:
@@ -77,4 +75,4 @@ By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-
 
 ## Additional Instrumentation
 
-For additional instrumentation, see the [OpenTelemetry Python documentation](https://github.com/open-telemetry/opentelemetry-python).
+For additional instrumentation, see the [OpenTelemetry JavaScript documentation](https://github.com/open-telemetry/opentelemetry-js).

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -63,7 +63,7 @@ remove the environment variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tr
 
 ## Configuration
 
-The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The ADOT Node.js layer combines both OpenTelemetry JavaScript and the ADOT Collector.
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -51,9 +51,9 @@ To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to 
 
 Tips:
 
-* By default, the layer is configured to [export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23),
- make sure your Lambda role has the required AWS X-Ray permissions.
-  See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+* By default, the layer is configured to export traces to AWS X-Ray.
+ Make sure your Lambda role has the required AWS X-Ray permissions.
+  For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Remove OpenTelemetry from your Lambda function
 To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
@@ -68,7 +68,7 @@ The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
  which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [page](/docs/getting-started/lambda)
+ see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda)
 
 
 <SectionSeparator />

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -53,9 +53,9 @@ To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to 
 
 Tips:
 
-* By default, the layer is configured to [export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23),
- make sure your Lambda role has the required AWS X-Ray permissions.
-  See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+* By default, the layer is configured to export traces to AWS X-Ray.
+ Make sure your Lambda role has the required AWS X-Ray permissions.
+  For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Remove OpenTelemetry from your Lambda function
 To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
@@ -70,7 +70,7 @@ The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
  which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [page](/docs/getting-started/lambda)
+ see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda)
 
 
 <SectionSeparator />

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -65,7 +65,7 @@ remove the environment variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tr
 
 ## Configuration
 
-The ADOT Java Auto Agent layer combines both OpenTelemetry Auto Agent and the ADOT Collector.
+The ADOT Python layer combines both OpenTelemetry Python and the ADOT Collector.
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -1,0 +1,107 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Support For Python'
+description:
+    The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides a plug and play user experience by automatically 
+    instrumenting a Lambda function, by packaging OpenTelemetry Python together with an out-of-the-box configuration for AWS Lambda and 
+    AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code. Currently, this layer is 
+    only for Python Lambda functions.
+path: '/docs/getting-started/lambda-python'
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
+
+
+The AWS Distro for OpenTelemetry Lambda (ADOT Lambda) layer for AWS Lambda provides a plug and play user experience by automatically 
+instrumenting a Lambda function, by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) together 
+with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function 
+without changing code. Currently, this layer is only for Python Lambda functions.
+
+<SectionSeparator />
+
+## Requirements
+
+The Lambda layer supports Python 3.8 Lambda runtimes. For more information about supported Python versions, see the 
+[OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python/blob/master/README.md#supported-runtimes) and the [package on PyPi](https://pypi.org/project/opentelemetry-api/).
+
+To build the Lambda Layer, install the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)and 
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) tools.
+
+Configure the AWS CLI using [aws configure]. Provide your AWS credentials, 
+[with administrator permissions](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html#serverless-sam-cli-install-mac-iam-permissions), 
+and your chosen default Region.
+
+Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published. Make sure to publish 
+the layer in the same Regions as your Lambda functions.
+
+<SubSectionSeparator />
+
+### Build the Lambda Layer 
+
+In this section, we will pull, build, and publish a reusable Lambda layer for use with Python Lambda Functions. This includes a reduced version of the 
+[AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector), which runs as a Lambda extension.
+
+1. Download a local copy of the [aws-otel-lambda repository from Github](https://github.com/aws-observability/aws-otel-lambda/archive/main.zip).
+2. Unzip the downloaded repository and run the `run.sh` script from the sample-apps directory. This publishes the layer into your personal account.
+    ```
+    cd sample-apps/python-lambda && clear
+    ```
+
+Tips:
+* To publish the layer to other Regions, use  `-r`, for example `./run.sh -r us-west-2`
+* After the layer is published, it can be reused across multiple Lambda functions. You don’t have to republish the layer, unless you would like to upgrade the layer to the latest version.
+
+You will need the layer Amazon Resource Name (ARN) to add it to your Lambda function. To get the ARN from another region, use `-r <region>` as shown previously.
+
+```
+ # Get the Lambda layer ARN
+ ./run.sh -l 
+```
+
+<SubSectionSeparator />
+
+### Enable auto-instrumentation for your Lambda function
+
+To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
+
+1. Open the Lambda function you intend to instrument in the in AWS console. 
+2. In the **Layers in Designer** section, choose **Add a layer**.
+3.  Under **specify an ARN**, paste the layer ARN, and then choose **Add**.
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER = /opt/python/adot-instrument` to your Lambda function. This enable auto-instumentations.
+5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
+
+Tips:
+
+* By default, the layer is configured to 
+[export traces to AWS X-Ray](https://github.com/aws-observability/aws-otel-lambda/blob/main/sample-apps/python-lambda/template.yml#L23), 
+make sure your Lambda role has the required X-Ray permissions.
+
+<SubSectionSeparator />
+
+### Remove OpenTelemetry from your Lambda function
+
+To disable OpenTelemetry for you Lambda function, remove the Lambda layer, remove the environment 
+variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
+
+<SectionSeparator />
+
+## Configuration 
+
+The ADOT Python Lambda layer combines both OpenTelemetry Python and the ADOT Collector. The configuration of the ADOT Collector follows the OpenTelemetry standard.
+
+By default, the ADOT Lambda layer uses [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/extensions/aoc-extension/config.yaml), 
+which exports telemetry data to AWS X-Ray and AWS CloudWatch.
+
+For debugging, you can turn on the logging exporter in the Collector by adding the environment variable `ADOT_DEBUG=true` in the Lambda function.
+
+To fully customize the Collector config, there are two options:
+* Bring customized config file (and ca/cert/key files) into the Lambda function by the Lambda layer, then set the Collector config by environment variable `ADOT_CONFIG=<your config file path>`
+* Add the environment variable `ADOT_CONFIG_CONTENT=<Full content of your config file>`
+
+For more information about ADOT Collector configuration like adding ca/cert/key files, see the Github 
+[README.md](https://github.com/aws-observability/aws-otel-lambda/blob/main/extensions/sample-aoc-config/README.md).
+
+
+
+
+


### PR DESCRIPTION
## Description
* Replace `Lambda for Python` to `Lambda` in Getting Started navigation bar
* Added the lambda landing page for all supported layers
* added `Lambda for Python` page into landing pages
* added `lambda for JS` page in the landing page
* added `lambda for Java` page in the landing page
* added `lambda for Java Auto Instrumentation` page in the landing page

## Test 
built the page locally
![image](https://user-images.githubusercontent.com/5331577/116452826-006e3680-a813-11eb-88ec-6b5c65f192bb.png)
