### PR TITLE
Add information about New Relic OTLP endpoint pre-release

### DIFF
--- a/src/docs/partners/new-relic.mdx
+++ b/src/docs/partners/new-relic.mdx
@@ -7,6 +7,10 @@ path: '/docs/partners/newrelic'
 
 # Overview
 
+:sparkles: **[New Relic offers OTLP (OpenTelemetry Protocol) Ingest as a pre-release! To sign up, click here!](https://forms.gle/fa2pWcQxgVQYMggEA)** :sparkles:
+
+This means you can configure the AWS OpenTelemetry Collector to use the OTLP exporter and no longer need this exporter to send data to New Relic.
+
 New Relic's OpenTelemetry Collector Exporter sends `trace`, `metric`, and `resource` data from the AWS OpenTelemetry Collector to New Relic. This capability gives you the power of instrumenting your entire stack for complete visibility and interoperability on the New Relic One platform. Use our curated out-of-the-box experiences and flexible visualization tools to quickly gain insight into how all your apps, systems and components are performing.
 
 ## Requirements


### PR DESCRIPTION
New Relic has a native OTLP endpoint. It is currently in pre-release. When it is GA'ed we plan to deprecate the New Relic exporter for the collector.