### PR TITLE
Update Blog Posts

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,79 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry adds Lambda layers for more languages and Collector"
+    author: "Alolita Sharma and Nizar Tyrewalla"
+    date: "29-Apr-2021"
+    body:
+      "The latest release of the AWS Distro for OpenTelemetry (ADOT) now provides AWS-managed Lambda layers for Java, NodeJS, and Python
+       for an easier getting-started experience for customers sending traces from their applications to AWS X-Ray. ADOT 0.9.0 also now 
+       provides a Lambda layer for the OpenTelemetry Collector for customers ..."
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-adds-lambda-layers-for-more-languages-and-collector/"
+
+  - title: "AWS One Observability Demo Workshop: What’s new with Prometheus, Grafana, and OpenTelemetry "
+    author: "Imaya Kumar Jagannathan, Rodrigue Koffi, and Rafael Pereyra"
+    date: "22-Apr-2021"
+    body:
+      "Amazon Web Services (AWS) offers a variety of observability services and tools to gain visibility and insights about your 
+      workload’s health and performance. For example, Amazon CloudWatch and AWS X-Ray offer a variety of features to collect, ingest, 
+      and perform operations on traces, metrics, and log data generated from workloads ..."
+    link: "https://aws.amazon.com/blogs/opensource/aws-one-observability-demo-workshop-whats-new-with-prometheus-grafana-and-opentelemetry/"
+
+  - title: "Tracing AWS Lambda functions in AWS X-Ray with OpenTelemetry"
+    author: "Manish Dhawaria"
+    date: "01-Apr-2021"
+    body:
+      "AWS Distro for OpenTelemetry is a secure, Amazon Web Services (AWS)-supported, production-ready distribution of the Cloud 
+      Native Computing Foundation (CNCF) OpenTelemetry project that provides open source APIs, libraries, and agents to collect 
+      distributed traces and metrics for application monitoring ..."
+    link: "https://aws.amazon.com/blogs/opensource/tracing-aws-lambda-functions-in-aws-x-ray-with-opentelemetry/"
+
+  - title: "AWS Distro for OpenTelemetry adds StatsD and Java support"
+    author: "Alolita Sharma and Nizar Tyrewalla"
+    date: "24-Mar-2021"
+    body:
+      "The StatsD receiver is part of the OpenTelemetry Collector and collects StatsD metrics for exporting to your 
+      choice of monitoring service. This StatsD receiver collects metrics to send to Amazon CloudWatch. The receiver aggregates 
+      and summarizes telemetry data for a user-defined aggregation interval ..."
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-adds-statsd-and-java-support/"
+
+  - title: "AWS Distro for OpenTelemetry adds .NET tracing support"
+    author: "Alolita Sharma and Nizar Tyrewalla"
+    date: "24-Feb-2021"
+    body:
+      "AWS Distro for OpenTelemetry (ADOT) v 0.7.0 is now available with .NET support. This release adds support 
+      for tracing .NET applications using open source OpenTelemetry’s .NET API and SDK. You can use AWS monitoring 
+      backends, such as AWS X-Ray, as well as partner monitoring solutions"
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-adds-net-tracing-support/"
+
+  - title: "Building a Prometheus Remote Write Exporter for the OpenTelemetry Python SDK"
+    author: "Alolita Sharma"
+    date: "10-Feb-2021"
+    body:
+      "As software deployments become increasingly more complex, the ability to better understand our applications and 
+      infrastructure also becomes vitally important. This ability can be achieved through observability, which deals with 
+      understanding the internal state of a system based on its external outputs. This process goes beyond just 
+      simple monitoring.  ..."
+    link: "https://aws.amazon.com/blogs/opensource/building-a-prometheus-remote-write-exporter-for-the-opentelemetry-python-sdk/"
+
+  - title: "AWS Distro for OpenTelemetry adds partner exporters for metrics and traces"
+    author: "Alolita Sharma and Nizar Tyrewalla"
+    date: "02-Feb-2021"
+    body:
+      "Today’s release of AWS Distro for OpenTelemetry (ADOT) 0.7.0 adds support for four more partner monitoring 
+      solutions—Datadog, Dynatrace, New Relic, and Splunk—enabling customers to send correlated metrics and traces 
+      using OpenTelemetry ..."
+    link: "https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-adds-partner-exporters-for-metrics-and-traces/"
+
+  - title: "Migrating X-Ray tracing to AWS Distro for OpenTelemetry"
+    author: "Michael Hausenblas"
+    date: "15-Jan-2021"
+    body:
+      "In the context of containerized microservices, we face the challenge of being able to tell where along the 
+      request path things happen and efficiently drill into signals. As a developer, you don’t want to fly blind and 
+      one popular way to provide these insights is distributed tracing ... "
+    link: "https://aws.amazon.com/blogs/opensource/migrating-x-ray-tracing-to-aws-distro-for-opentelemetry/"
+
   - title: "Enhancing AWS X-Ray support in OpenTelemetry JavaScript SDK"
     author: "Kelvin Lo and Alolita Sharma"
     date: "21-Dec-2020"


### PR DESCRIPTION
This PR updates the aws-otel.github.io site with the latest blogposts from [AWS Distro for OpenTelemetry](https://aws.amazon.com/otel/?otel-blogs.sort-by=item.additionalFields.createdDate&otel-blogs.sort-order=desc)