### PR TITLE
Update some content to point to OpenSearch rather than ODFE

### DIFF
--- a/src/content/SiteContent/resource-page.yaml
+++ b/src/content/SiteContent/resource-page.yaml
@@ -32,12 +32,10 @@ projects:
     description:
       Grafana is an open source visualization framework that allows you to query, visualize, alert on and understand your metrics.
     link: https://github.com/grafana/grafana
-  - title: Open Distro for Elasticsearch
+  - title: OpenSearch
     description:
-      Open Distro for ElasticSearch is an Apache 2.0-licensed distribution of Elasticsearch enhanced with enterprise
-      security, alerting, and more. It allows you to keep your data secure, get notified automatically, query with
-      familiar tools and get deep diagnostic insights.
-    link: https://opendistro.github.io/for-elasticsearch/
+      OpenSearch is an Apache 2.0-licensed distributed search and analytics engine derived from Elasticsearch OSS 7.10.2. OpenSearch offers enterprise security, data notifications, automated index management, and more. Keep your data secure, query it using familiar tools, and get deep diagnostic insights.
+    link: https://opensearch.org
   - title: OpenMetrics
     description:
       OpenMetrics specifies a popular standard for transmitting cloud-native metrics at scale, with support for both text representation 
@@ -59,8 +57,8 @@ projects:
 blogs:
   - title: AWS Open Source
     link: https://aws.amazon.com/blogs/opensource/
-  - title: OpenDistro for Elasticsearch
-    link: https://opendistro.github.io/for-elasticsearch/blog/
+  - title: OpenSearch
+    link: https://opensearch.org/blog/
   - title: OpenTelemetry
     link: https://medium.com/opentelemetry
 
@@ -86,11 +84,9 @@ searchIndex:
   Cortex provides horizontally scalable, highly available, multi-tenant, long term storage for Prometheus. Cortex is
   horizontally scalable, highly available, multi-tenant and provides long term storage.
 
-  Open Distro for Elasticsearch
+  OpenSearch
 
-  Open Distro for ElasticSearch is an Apache 2.0-licensed distribution of Elasticsearch enhanced with enterprise
-  security, alerting, and more. It allows you to keep your data secure, get notified automatically, query with
-  familiar tools and get deep diagnostic insights.
+  OpenSearch is an Apache 2.0-licensed distributed search and analytics engine derived from Elasticsearch OSS 7.10.2. OpenSearch offers enterprise security, data notifications, automated index management, and more. Keep your data secure, query it using familiar tools, and get deep diagnostic insights.
 
   OpenTelemetry
 
@@ -106,6 +102,6 @@ searchIndex:
 
   Related Blogs
   AWS Open Source
-  OpenDistro for Elasticsearch
+  OpenSearch
   OpenTelemetry
   "

--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -202,15 +202,15 @@ exporters:
 
 <SectionSeparator />
 
-## Open Distro for Elasticsearch
-Open Distro for Elasticsearch (ODFE) supports ingesting enchriched trace data via [Data Prepper](https://opendistro.github.io/for-elasticsearch-docs/docs/trace/get-started/), a standalone application that converts OLTP formatted data to be used by ODFE. Data Prepper supports receiving trace data from OpenTelemetry natively via OTLP. Once you've set up a Data Prepper instance, completing the data pipeline is as simple as editing your YAML config file for the Collector and getting started.
+## OpenSearch
+OpenSearch supports ingesting enchriched trace data via [Data Prepper](https://github.com/opensearch-project/data-prepper), a standalone application that converts OLTP formatted data for use in OpenSearch. Data Prepper supports receiving trace data from OpenTelemetry natively via OTLP. Once you've set up a Data Prepper instance, completing the data pipeline is as simple as editing your YAML config file for the Collector and getting started.
 
 <SubSectionSeparator />
 
 ### Requirements
-Before you can use the AWS Distro for OpenTelemetry with Open Distro for Elasticsearch, you need:
+Before you can use the AWS Distro for OpenTelemetry with OpenSearch, you need:
 
-* A Data Prepper instance, configured to write to your ODFE cluster. Configuration documentation can be found [here](https://opendistro.github.io/for-elasticsearch-docs/docs/trace/data-prepper/).
+* A Data Prepper instance, configured to write to your OpenSearch cluster. Configuration documentation can be found [here](https://docs-beta.opensearch.org/monitoring-plugins/trace/data-prepper/).
 
 <SubSectionSeparator />
 


### PR DESCRIPTION
I didn't actually rebuild the website locally, so someone should probably do so pre-merge to make sure I didn't introduce any new errors.