### PR TITLE
Update docs for OTel Python 1.3

### DIFF
--- a/src/docs/getting-started/python-sdk.mdx
+++ b/src/docs/getting-started/python-sdk.mdx
@@ -20,7 +20,7 @@ In this tutorial, we will introduce how to use OpenTelemetry Python SDK for manu
 * [Manual Instrumentation with the Python SDK](/docs/getting-started/python-sdk/trace-manual-instr)
 
 ## Sample Code with Python SDK 
-* [Sample applications on GitHub](https://github.com/aws-observability/aws-otel-python/tree/mainline/sample-apps)
+* [Sample applications on GitHub](https://github.com/aws-observability/aws-otel-python/tree/main/integration-test-apps)
 
 
 

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -57,15 +57,6 @@ Set the `OTEL_PROPAGATORS` environment variable to use the AWS X-Ray Propagator.
 OTEL_PROPAGATORS=aws_xray
 ```
 
-Alternatively, you can set the global propagator in code. Configure the propagator before your code starts, as shown below.
-
-```python lineNumbers=true 
-from opentelemetry import propagate
-from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import AwsXRayFormat
-
-propagate.set_global_textmap(AwsXRayFormat())
-```
-
 <SubSectionSeparator />
 
 ### Run the application 
@@ -73,6 +64,8 @@ propagate.set_global_textmap(AwsXRayFormat())
 Auto instrumentation uses the `opentelemetry-instrument` wrapper executable to automatically initialize the installed instrumentors and start the provided application. Environment variables are used to configure the connection to the ADOT Collector and command line arguments are used to configure trace generation for AWS X-Ray.
 
 The `IdGenerator` can be configured with the environment variables `OTEL_PYTHON_ID_GENERATOR=aws_xray` or the `opentelemetry-instrument` command line argument `--id-generator=aws_xray`.
+
+The `SpanExporter` can be configured with the environment variables `OTEL_TRACES_EXPORTER=otlp` or the `opentelemetry-instrument` command line argument `--trace-exporter=otlp`. However, if `opentelemetry-distro[otlp]` is used, it already uses the `otlp` exporter by default with any more configuration.
 
 The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).
 
@@ -89,9 +82,9 @@ Starting an application which connects to a Collector running as a sidecar witho
 ```bash
 $ OTEL_EXPORTER_OTLP_INSECURE=True \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
-opentelemetry-instrument --trace-exporter otlp \
-                         --ids-generator aws_xray \
-                         python ./path/to/your/app.py
+OTEL_PROPAGATORS=aws_xray \
+OTEL_PYTHON_ID_GENERATOR=aws_xray \
+opentelemetry-instrument python ./path/to/your/app.py
 ```
 
 Starting an application which connects to a Collector running as a sidecar without TLS using flask:
@@ -100,9 +93,9 @@ Starting an application which connects to a Collector running as a sidecar witho
 $ OTEL_EXPORTER_OTLP_INSECURE=True \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
 FLASK_APP=./my_flask_app.py \
-opentelemetry-instrument --trace-exporter otlp \
-                         --ids-generator aws_xray \
-                         flask run
+OTEL_PROPAGATORS=aws_xray \
+OTEL_PYTHON_ID_GENERATOR=aws_xray \
+opentelemetry-instrument flask run
 ```
 
 Starting an application which connects to a Collector running as a service with TLS:
@@ -110,9 +103,9 @@ Starting an application which connects to a Collector running as a service with 
 ```bash
 $ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt \
 OTEL_EXPORTER_OTLP_ENDPOINT=collector.service.local \
-opentelemetry-instrument --trace-exporter otlp \
-                         --ids-generator aws_xray \
-                         python ./path/to/your/app.py
+OTEL_PROPAGATORS=aws_xray \
+OTEL_PYTHON_ID_GENERATOR=aws_xray \
+opentelemetry-instrument python ./path/to/your/app.py
 ```
 
 <SectionSeparator />

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -40,8 +40,8 @@ Go to the directory of the application which you want to instrument and run the 
 
 ```bash 
 $ # Install required packages for instumentation and tracing support for AWS X-Ray
-$ pip install opentelemetry-distro[otlp]~=0.1 \
-              opentelemetry-sdk-extension-aws~=0.1
+$ pip install opentelemetry-distro[otlp]>=0.22b0 \
+              opentelemetry-sdk-extension-aws>=0.22b0
 # Automatically install supported instrumentors for the application's dependencies
 $ opentelemetry-bootstrap --action=install
 ``` 

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -32,15 +32,16 @@ The OpenTelemetry instrumentation package automates much of the on-boarding proc
 
 ###  Install instrumentation packages
 
-You will need the `opentelemetry-distro` and `opentelemetry-instrumentation` packages from PyPi. This automatically installs the `opentelemetry-api` and `opentelemetry-sdk` packages. `opentelemetry-instrumentation` provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
+You will need to install the `opentelemetry-distro`, `opentelemetry-sdk`, and `opentelemetry-instrumentation` packages from PyPi. `opentelemetry-instrumentation` provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
 
 Go to the directory of the application which you want to instrument and run the following commands.
 
 ```bash 
 $ # Install required packages for instumentation and tracing support for AWS X-Ray
-$ pip install opentelemetry-distro[otlp]~=0.1
-$ pip install opentelemetry-instrumentation~=0.1
-$ pip install opentelemetry-sdk-extension-aws~=0.1
+$ pip install opentelemetry-distro[otlp]~=0.1 \
+              opentelemetry-instrumentation~=0.1 \
+              opentelemetry-sdk~=1.0 \
+              opentelemetry-sdk-extension-aws~=0.1
 # Automatically install supported instrumentors for the application's dependencies
 $ opentelemetry-bootstrap --action=install
 ``` 
@@ -89,8 +90,8 @@ Starting an application which connects to a Collector running as a sidecar witho
 $ OTEL_EXPORTER_OTLP_INSECURE=True \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
 opentelemetry-instrument --trace-exporter otlp \
-                        --ids-generator aws_xray \
-                        python ./path/to/your/app.py
+                         --ids-generator aws_xray \
+                         python ./path/to/your/app.py
 ```
 
 Starting an application which connects to a Collector running as a sidecar without TLS using flask:
@@ -100,8 +101,8 @@ $ OTEL_EXPORTER_OTLP_INSECURE=True \
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 \
 FLASK_APP=./my_flask_app.py \
 opentelemetry-instrument --trace-exporter otlp \
-                        --ids-generator aws_xray \
-                        flask run
+                         --ids-generator aws_xray \
+                         flask run
 ```
 
 Starting an application which connects to a Collector running as a service with TLS:
@@ -110,8 +111,8 @@ Starting an application which connects to a Collector running as a service with 
 $ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt \
 OTEL_EXPORTER_OTLP_ENDPOINT=collector.service.local \
 opentelemetry-instrument --trace-exporter otlp \
-                        --ids-generator aws_xray \
-                        python ./path/to/your/app.py
+                         --ids-generator aws_xray \
+                         python ./path/to/your/app.py
 ```
 
 <SectionSeparator />

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -10,17 +10,15 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
 
 
-The AWS Distro for OpenTelemetry Python (ADOT Python) provides functionality to [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) 
-for use with AWS X-Ray. OpenTelemetry Python supports automatic instrumentation, which instruments your application to gather telemetry data from a 
-diverse set of libraries and frameworks with minimal configuration. This data can then be exported to different back-ends in different formats.
+The AWS Distro for OpenTelemetry Python (ADOT Python) provides functionality to [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) for use with AWS X-Ray. OpenTelemetry Python supports automatic instrumentation, which instruments your application to gather telemetry data from a diverse set of libraries and frameworks with minimal configuration. This data can then be exported to different back-ends in different formats.
 
-In this tutorial, we introduce you to how to use the auto-instrumentation package for traces with AWS X-Ray.
+In this tutorial, we will introduce automatic instrumentation using ADOT Python for AWS X-Ray.
 
 <SectionSeparator />
 
 ## Requirements
 
-Python 3.5+ is required to use OpenTelemetry Python. Check your currently installed Python version using `python3 -V`.
+Python 3.6+ is required to use OpenTelemetry Python. Check your currently installed Python version using `python3 -V`.
 For more information about supported Python versions, see the [OpenTelemetry Python API package on PyPi](https://pypi.org/project/opentelemetry-api/).
 
 Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see 
@@ -34,16 +32,15 @@ The OpenTelemetry instrumentation package automates much of the on-boarding proc
 
 ###  Install instrumentation packages
 
-You’ll need the `opentelemetry-instrumentation` package from PyPi. This automatically installs the `opentelemetry-api` and `opentelemetry-sdk` packages. 
-It also provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
+You will need the `opentelemetry-distro` and `opentelemetry-instrumentation` packages from PyPi. This automatically installs the `opentelemetry-api` and `opentelemetry-sdk` packages. `opentelemetry-instrumentation` provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
 
-Go to the directory of the application, which currently imports these packages, and run the following commands.
+Go to the directory of the application which you want to instrument and run the following commands.
 
 ```bash 
 $ # Install required packages for instumentation and tracing support for AWS X-Ray
-$ pip install opentelemetry-instrumentation==0.16b1
-$ pip install opentelemetry-exporter-otlp==0.16b1
-$ pip install opentelemetry-sdk-extension-aws==0.16b1
+$ pip install opentelemetry-distro[otlp]~=0.1
+$ pip install opentelemetry-instrumentation~=0.1
+$ pip install opentelemetry-sdk-extension-aws~=0.1
 # Automatically install supported instrumentors for the application's dependencies
 $ opentelemetry-bootstrap --action=install
 ``` 
@@ -62,10 +59,10 @@ OTEL_PROPAGATORS=aws_xray
 Alternatively, you can set the global propagator in code. Configure the propagator before your code starts, as shown below.
 
 ```python lineNumbers=true 
-from opentelemetry import propagators
+from opentelemetry import propagate
 from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import AwsXRayFormat
 
-propagators.set_global_textmap(AwsXRayFormat())
+propagate.set_global_textmap(AwsXRayFormat())
 ```
 
 <SubSectionSeparator />
@@ -74,9 +71,11 @@ propagators.set_global_textmap(AwsXRayFormat())
 
 Auto instrumentation uses the `opentelemetry-instrument` wrapper executable to automatically initialize the installed instrumentors and start the provided application. Environment variables are used to configure the connection to the ADOT Collector and command line arguments are used to configure trace generation for AWS X-Ray.
 
+The `IdGenerator` can be configured with the environment variables `OTEL_PYTHON_ID_GENERATOR=aws_xray` or the `opentelemetry-instrument` command line argument `--id-generator=aws_xray`.
+
 The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).
 
-We can use the `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678` environment variable to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
+We can use the `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678` environment variable to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:4317`.
 
 If the Collector the application will connect to is running without TLS configured, the `OTEL_EXPORTER_OTLP_INSECURE=True` environment variable is used to disable client transport security for an SDK OTLP exporter’s connection. This will use the gRPC insecure_channel() method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
 
@@ -87,22 +86,34 @@ If the Collector the application will connect to is running with TLS configured,
 Starting an application which connects to a Collector running as a sidecar without TLS:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+$ OTEL_EXPORTER_OTLP_INSECURE=True \
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
+opentelemetry-instrument --trace-exporter otlp \
+                        --ids-generator aws_xray \
+                        python ./path/to/your/app.py
 ```
 
 Starting an application which connects to a Collector running as a sidecar without TLS using flask:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_INSECURE=True OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 FLASK_APP=./my_flask_app.py opentelemetry-instrument -e otlp --ids-generator aws_xray flask run
+$ OTEL_EXPORTER_OTLP_INSECURE=True \
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 \
+FLASK_APP=./my_flask_app.py \
+opentelemetry-instrument --trace-exporter otlp \
+                        --ids-generator aws_xray \
+                        flask run
 ```
 
 Starting an application which connects to a Collector running as a service with TLS:
 
 ```bash
-$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt OTEL_EXPORTER_OTLP_ENDPOINT=collector.service.local opentelemetry-instrument -e otlp --ids-generator aws_xray python ./path/to/your/app.py
+$ OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/my-cert.crt \
+OTEL_EXPORTER_OTLP_ENDPOINT=collector.service.local \
+opentelemetry-instrument --trace-exporter otlp \
+                        --ids-generator aws_xray \
+                        python ./path/to/your/app.py
 ```
 
 <SectionSeparator />
 
-Custom tracing works the same way when using automatic instrumentation or manual instrumentation. For information about trace instrumentation, see 
-[custom tracing manual instrumentation](/docs/getting-started/python-sdk/trace-manual-instr).
+Custom tracing works the same way when using automatic instrumentation or manual instrumentation. For information about custom trace instrumentation, see our [docs on manual instrumentation](/docs/getting-started/python-sdk/trace-manual-instr).

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -32,15 +32,15 @@ The OpenTelemetry instrumentation package automates much of the on-boarding proc
 
 ###  Install instrumentation packages
 
-You will need to install the `opentelemetry-distro`, `opentelemetry-sdk`, and `opentelemetry-instrumentation` packages from PyPi. `opentelemetry-instrumentation` provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
+You will need to install the `opentelemetry-distro` package from PyPi. This automatically installs the `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-instrumentation` packages. `opentelemetry-instrumentation` provides commands to detect, install, and initialize all instrumentation packages supported for your application’s dependencies.
+
+Also, you will want to install `opentelemetry-sdk-extension-aws` to make traces compatible with AWS X-Ray.
 
 Go to the directory of the application which you want to instrument and run the following commands.
 
 ```bash 
 $ # Install required packages for instumentation and tracing support for AWS X-Ray
 $ pip install opentelemetry-distro[otlp]~=0.1 \
-              opentelemetry-instrumentation~=0.1 \
-              opentelemetry-sdk~=1.0 \
               opentelemetry-sdk-extension-aws~=0.1
 # Automatically install supported instrumentors for the application's dependencies
 $ opentelemetry-bootstrap --action=install

--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -98,7 +98,7 @@ Starting an application which connects to a Collector running as a sidecar witho
 
 ```bash
 $ OTEL_EXPORTER_OTLP_INSECURE=True \
-OTEL_EXPORTER_OTLP_ENDPOINT=localhost:55678 \
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
 FLASK_APP=./my_flask_app.py \
 opentelemetry-instrument --trace-exporter otlp \
                          --ids-generator aws_xray \

--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -10,18 +10,15 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
 
 
-AWS Distro for OpenTelemetry (ADOT) Python is a distribution of [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) 
-with components to trace applications in a format compatible with the AWS X-Ray service. This enables all the features of the OpenTelemetry 
-project and configures its components to create traces that can be viewed in the AWS X-Ray console and allow propagation of those contexts 
-across multiple downstream AWS services.
+AWS Distro for OpenTelemetry Python (ADOT Python) is a distribution of [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python) with components to trace applications in a format compatible with the AWS X-Ray service. This enables all the features of the OpenTelemetry project and configures its components to create traces that can be viewed in the AWS X-Ray console and allow propagation of those contexts across multiple downstream AWS services.
 
-In this tutorial, we will introduce you to how to use the manual instrumentation package for traces for use with AWS X-Ray.
+In this tutorial, we will introduce manual instrumentation using ADOT Python for AWS X-Ray.
 
 <SectionSeparator />
 
 ## Requirements
 
-Python 3.5+ is required to use ADOT Python. Check your currently installed python version using `python3 -V`. For more information about supported Python versions, see the [OpenTelemetry API Python package on PyPi](https://pypi.org/project/opentelemetry-api/). Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see [Getting Started with the AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/collector).
+Python 3.6+ is required to use ADOT Python. Check your currently installed python version using `python3 -V`. For more information about supported Python versions, see the [OpenTelemetry API Python package on PyPi](https://pypi.org/project/opentelemetry-api/). Make sure you have AWS Distro for OpenTelemetry Collector (ADOT Collector) running. To set up the collector, see [Getting Started with the AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/collector).
 
 <SectionSeparator />
 
@@ -30,10 +27,10 @@ Python 3.5+ is required to use ADOT Python. Check your currently installed pytho
 Install the following packages from OpenTelemetry Python using pip.
 
 ```bash
-$ pip install opentelemetry-api==0.16b1 \
-              opentelemetry-sdk==0.16b1 \
-              opentelemetry-exporter-otlp==0.16b1 \
-              opentelemetry-sdk-extension-aws==0.16b1
+$ pip install opentelemetry-api~=1.0 \
+              opentelemetry-sdk~=1.0 \
+              opentelemetry-exporter-otlp~=1.0 \
+              opentelemetry-sdk-extension-aws~=0.1
 ```
 
 OpenTelemetry Python distributes many packages, which provide instrumentation for well-known Python dependencies. You need to install the relevant 
@@ -42,8 +39,8 @@ the [OpenTelemetry Registry](https://opentelemetry.io/registry/?s=python).
 
 ```bash
 # Supported instrumentation packages for the dependencies of the example above
-$ pip install opentelemetry-instrumentation-flask==0.16b1
-$ pip install opentelemetry-instrumentation-botocore==0.16b1
+$ pip install opentelemetry-instrumentation-flask~=0.1
+$ pip install opentelemetry-instrumentation-botocore~=0.1
 ```
 
 <SectionSeparator />
@@ -60,8 +57,7 @@ import json
 
 # Add imports for OTel components into the application
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.trace_exporter import OTLPSpanExporter
-from opentelemetry.trace import SpanKind
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
@@ -71,11 +67,11 @@ from opentelemetry.sdk.extension.aws.trace import AwsXRayIdsGenerator
 
 Next, configure the Global Tracer Provider to export to the ADOT Collector. The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).
 
-The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:55680`.
+The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If the address is unset, it will instead try to connect to `localhost:4317`.
 
 If the Collector the application will connect to is running without TLS configured, the `insecure=True` argument is used to disable client transport security for our OTLP exporter’s connection. This will use the gRPC `insecure_channel()` method as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=insecure#grpc.insecure_channel). This option should never be used in production, non-sidecar deployments.
 
-If the Collector the application will connect to is running with TLS configured, the `credentials=/path/to/cert.pem` argument is used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method ssl_channel_credentials() will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
+If the Collector the application will connect to is running with TLS configured, the `credentials=/path/to/cert.pem` argument is used to give a path to credentials to be used to establish a secure connection for the app’s exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates. If no certificate is found, the gRPC method `ssl_channel_credentials()` will attempt to “retrieve the PEM-encoded root certificates from a default location chosen by gRPC runtime” as explained in the [gRPC Python Documentation](https://grpc.github.io/grpc/python/grpc.html?highlight=ssl_channel_credentials).
 
 #### Example TracerProvider configuration
 
@@ -83,19 +79,22 @@ Connecting to an ADOT Collector running as a sidecar, we can set up the TracerPr
 
 ```python lineNumbers=true
 # Sends generated traces in the OTLP format to an ADOT Collector running on port 55678
-otlp_exporter = OTLPSpanExporter(endpoint="localhost:55678", insecure=True)
+otlp_exporter = OTLPSpanExporter(endpoint="localhost:4317", insecure=True)
 # Processes traces in batches as opposed to immediately one after the other
 span_processor = BatchExportSpanProcessor(otlp_exporter)
 # Configures the Global Tracer Provider
 trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor, ids_generator=AwsXRayIdsGenerator()))
 ```
 
+Instead of setting the `IdGenerator` of the `TracerProvider` in code,, you can set the `IdGenerator` using the `OTEL_PYTHON_ID_GENERATOR` environment variable:
+
+```
+OTEL_PYTHON_ID_GENERATOR=aws_xray
+```
+
 <SubSectionSeparator />
 
 ### Instrumenting packages
-
-To enable tracing through your package dependencies, you need to import and initialize the relevant instrumentor classes. Instrumentors have individual 
-initialization requirements, so refer to the instrumentor’s package README.md for configuration details.
 
 To enable tracing through your package dependencies, you need to import and initialize the relevant instrumentor classes. Instrumentors have individual 
 initialization requirements, so refer to the instrumentor’s package README.md for configuration details.
@@ -124,17 +123,17 @@ OTEL_PROPAGATORS=aws_xray
 Alternatively, you can set the global propagator in code. Configure the propagator before your main function, as shown below.
 
 ```python lineNumbers=true
-from opentelemetry import propagators
+from opentelemetry import propagate
 from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import AwsXRayFormat
 
-propagators.set_global_textmap(AwsXRayFormat())
+propagate.set_global_textmap(AwsXRayFormat())
 ```
 
 <SectionSeparator />
 
 ## Adding custom tracing
 
-You can add additional custom tracing in your application code using the tracer as shown in the following.
+You can add additional custom tracing in your application code using the tracer as follows:
 
 ```python lineNumbers=true
 # Get a tracer from the Global Tracer Provider
@@ -145,11 +144,11 @@ if __name__ == "__main__":
     # ... application code
     
     # start a new span
-    with tracer.start_as_current_span("app landing page root span"):
+    with tracer.start_as_current_span("Root Span"):
         print('Started a root span')
         
         # start a nested new span
-        with tracer.start_span("app landing page child span"):
+        with tracer.start_span("Child Span"):
             print('Started a child span')
             ec2_client = boto3.client('ec2')
             result = ec2_client.describe_instances()
@@ -158,4 +157,4 @@ if __name__ == "__main__":
 ```
 
 For additional resource regarding custom tracing, see the [OpenTelemetry for Python documentation](https://opentelemetry-python.readthedocs.io/en/stable/) or
-check out our [sample applications on Github](https://github.com/aws-observability/aws-otel-python/tree/mainline/sample-apps).
+check out our [sample applications on Github](https://github.com/aws-observability/aws-otel-python/tree/main/integration-test-apps).

--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -24,13 +24,13 @@ Python 3.6+ is required to use ADOT Python. Check your currently installed pytho
 
 ## Getting the SDK and dependencies
 
-Install the following packages from OpenTelemetry Python using pip.
+Install the following packages and its dependencies from OpenTelemetry Python using pip.
 
 ```bash
 $ pip install opentelemetry-api~=1.0 \
               opentelemetry-sdk~=1.0 \
+              opentelemetry-sdk-extension-aws>=0.22b0 \
               opentelemetry-exporter-otlp~=1.0 \
-              opentelemetry-sdk-extension-aws~=0.1
 ```
 
 OpenTelemetry Python distributes many packages, which provide instrumentation for well-known Python dependencies. You need to install the relevant 
@@ -39,8 +39,8 @@ the [OpenTelemetry Registry](https://opentelemetry.io/registry/?s=python).
 
 ```bash
 # Supported instrumentation packages for the dependencies of the example above
-$ pip install opentelemetry-instrumentation-flask~=0.1
-$ pip install opentelemetry-instrumentation-botocore~=0.1
+$ pip install opentelemetry-instrumentation-flask>=0.22b0
+$ pip install opentelemetry-instrumentation-botocore>=0.22b0
 ```
 
 <SectionSeparator />


### PR DESCRIPTION
Since OTel Python has moved to 1.3, some of the imports have changed. Also some links in our repo have changed. This PR bridges those gaps.