### PR TITLE
Update ADOT Python+JS+Java+Collector Lambda Layer ARNs

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -69,7 +69,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-27-0:1 | Contains the [ADOT Collector for Lambda v0.10.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.10.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-29-1:1 | Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
 
 
 ### Enable Tracing

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.10.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.10.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-2-0:1 | Contains [OpenTelemetry for Java v1.2.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) with [Java Instrumentation v1.2.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.10.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.10.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-2-0:1 | Contains [OpenTelemetry for Java v1.2.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) with [Java Instrumentation v1.2.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-19-0:1 | Contains [OpenTelemetry for JavaScript v0.19.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.19.0) with [Contrib v0.16.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.16.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.10.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.10.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-23-0:1 | Contains [OpenTelemetry for JavaScript v0.23.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.23.0) with [Contrib v0.23.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.23.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -32,7 +32,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-2-0:1 | Contains [OpenTelemetry for Python v1.2.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0) with [Contrib v0.21b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.21b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.10.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.10.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-2-0:1 | Contains [OpenTelemetry for Python v1.3.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0) with [Contrib v0.22b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.22b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
# Description

With the release of new upstream OTel SDKs, we update our documentation to point to the most recently released public Lambda layers which are deployed with updated SDKs.

These updates contain:
* ADOT python Lambda Layer 1.3.0
  * OTel Python Core 1.3.0
  * OTel Python Contrib 0.22b0
  * ADOT collector 0.29.1
* ADOT nodejs Lambda Layer 0.23.0
  * OTel JS Core 0.23.0
  * OTel JS Contrib 0.23.0
  * ADOT collector 0.29.1
* ADOT java-agent Lambda Layer 1.2.0
  * ADOT collector 0.29.1
* ADOT java-wrapper Lambda Layer 1.2.0
  * ADOT collector 0.29.1