### PR TITLE
Edits to fix ARNs from July 8 release

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | aarn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-2-0:1 | Contains [OpenTelemetry for Java v1.2.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) with [Java Instrumentation v1.2.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-2-0:2 | Contains [OpenTelemetry for Java v1.2.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) with [Java Instrumentation v1.2.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -32,7 +32,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-2-0:1 | Contains [OpenTelemetry for Python v1.3.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0) with [Contrib v0.22b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.22b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-3-0:1 | Contains [OpenTelemetry for Python v1.3.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0) with [Contrib v0.22b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.22b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
# Description

Following #132 where we updated the ARNs for the July 8 release, we missed some small changes to the ARNs where the new Lambda Layers were published. This PR changes the ARNs to the correct ones.