### PR TITLE
Update New Relic page with data on sending OTLP.

### DIFF
--- a/src/docs/partners/new-relic.mdx
+++ b/src/docs/partners/new-relic.mdx
@@ -7,75 +7,21 @@ path: '/docs/partners/newrelic'
 
 # Overview
 
-:sparkles: **[New Relic offers OTLP (OpenTelemetry Protocol) Ingest as a pre-release! To sign up, click here!](https://forms.gle/fa2pWcQxgVQYMggEA)** :sparkles:
+✨ **[New Relic offers OTLP (OpenTelemetry Protocol) Ingest! No exporter is required. To sign up, click here!](https://forms.gle/fa2pWcQxgVQYMggEA)** ✨
 
-This means you can configure the AWS OpenTelemetry Collector to use the OTLP exporter and no longer need this exporter to send data to New Relic.
 
-New Relic's OpenTelemetry Collector Exporter sends `trace`, `metric`, and `log` data from the AWS OpenTelemetry Collector to New Relic. This capability gives you the power of instrumenting your entire stack for complete visibility and interoperability on the New Relic One platform. Use our curated out-of-the-box experiences and flexible visualization tools to quickly gain insight into how all your apps, systems and components are performing.
+New Relic's platform can receive `trace`, `metric`, and `log` data from the AWS OpenTelemetry Collector via OTLP. This capability gives you the power of instrumenting your entire stack for complete visibility and interoperability on the New Relic One platform. Use our curated out-of-the-box experiences and flexible visualization tools to quickly gain insight into how all your apps, systems and components are performing.
 
 
 ## Requirements
 
 1. The New Relic OpenTelemetry Collector exporter is included in the AWS OTel Collector. It requires a functioning instance of the AWS OTel Collector to operate.
 2. If you have not already done so, [create your New Relic account](https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account).
-3. Create an ingest API key using New Relic’s [API Keys UI](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
+3. Create an ingest license key using New Relic’s [API Keys UI](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
 
 ## Configuration
 
-The following configuration must be added to your existing AWS OTel Collector configuration yaml file.
-
-1. Add the `newrelic` exporter to the list of configured exporters for traces, metrics, and logs in the `service` section:
-
-  ```yaml
-  service:
-    pipelines:
-      traces:
-        exporters: [newrelic]
-      metrics:
-        exporters: [newrelic]
-      logs:
-        exporters: [newrelic]
-  ```
-
-2. Add the `newrelic` configuration to the `exporters` section with your New Relic Ingest API Key:
-
-  ```yaml
-  exporters:
-    newrelic:
-      apikey: your_ingest_api_key_goes_here
-  ```
-
-## New Relic Exporter Configuration Options
-
-#### apikey (Required)
-
-Your New Relic Insights Insert API Key or License Key.
-
-#### timeout (Optional)
-
-Amount of time spent attempting a request before abandoning and dropping data.
-
-Default is 15 seconds.
-
-#### Example EU configuration
-
-```yaml
-exporters:
-  newrelic:
-    apikey: super-secret-api-key
-    timeout: 30s
-
-    # host_override is set to send data to New Relic's EU data centers.
-    traces:
-      host_override: trace-api.eu.newrelic.com
-    metrics:
-      host_override: metric-api.eu.newrelic.com
-    logs:
-      host_override: log-api.eu.newrelic.com
-```
-
-
-## Complete example configuration
+Here's an example OpenTelemetry Collector configuration (OTLP Input OpenTelemetry Collector YAML):
 
 ```yaml
 receivers:
@@ -88,24 +34,25 @@ processors:
   batch:
 
 exporters:
-  newrelic:
-    apikey: your_ingest_api_key_goes_here
-    timeout: 30s
+  otlp:
+    endpoint: ${NEW_RELIC_ENDPOINT}
+    headers:
+      api-key: ${NEW_RELIC_LICENSE_KEY}
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [newrelic]
+      exporters: [otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [newrelic]
+      exporters: [otlp]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [newrelic]
+      exporters: [otlp]
 ```
 
 ## Support


### PR DESCRIPTION
New Relic is capable of receiving OTLP traffic; therefore, a decision
has been made to remove the newrelicexporter component from all third
party distributions.

The newrelicexporter component should be considered deprecated.

Information about OTLP ingest is available to customers at
https://forms.gle/fa2pWcQxgVQYMggEA