### PR TITLE
Typo fixes for Lambda Getting Started docs

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -75,7 +75,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.
 
-1. Open the Lambda function you intend to trace in the in AWS console. 
+1. Open the Lambda function you intend to trace in the AWS console. 
 2. In the **Layers** section, choose **Add a layer**.
 3. Under **Specify an ARN**, paste the layer ARN, and then choose **Add**.
 

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -35,10 +35,10 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
-1. Open the Lambda function you intend to instrument in the in AWS console. 
+1. Open the Lambda function you intend to instrument in the AWS console. 
 2. In the *Layers in Designer* section, choose *Add a layer*.
 3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
-4. Add the environment variable AWS_LAMBDA_EXEC_WRAPPER and set to one of the following options:
+4. Add the environment variable AWS_LAMBDA_EXEC_WRAPPER and set it to one of the following options:
     1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -45,10 +45,10 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
-1. Open the Lambda function you intend to instrument in the in AWS console.
+1. Open the Lambda function you intend to instrument in the AWS console.
 2. In the *Layers in Designer* section, choose *Add a layer*.
 3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
-4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to one of the following options:
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to one of the following options:
     1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
     2. `/opt/otel-proxy-handler` - for wrapping regular handlers (implementing RequestHandler) proxied through API Gateway, enabling HTTP context propagation
     3. `/opt/otel-stream-handler` - for wrapping streaming handlers (implementing RequestStreamHandler), enabling HTTP context propagation for HTTP requests

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -35,10 +35,10 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
-1. Open the Lambda function you intend to instrument in the in AWS console.
+1. Open the Lambda function you intend to instrument in the AWS console.
 2. In the *Layers in Designer* section, choose *Add a layer*.
 3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
-4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to `/opt/otel-handler`.
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to `/opt/otel-handler`.
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 
 Tips:

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -38,10 +38,10 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
-1. Open the Lambda function you intend to instrument in the in AWS console.
+1. Open the Lambda function you intend to instrument in the AWS console.
 2. In the *Layers in Designer* section, choose *Add a layer*.
 3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
-4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set to `/opt/otel-instrument`.
+4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to `/opt/otel-instrument`.
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 
 Tips:


### PR DESCRIPTION
Quick PR to update some typos in the Getting Started docs.

* Changes `in the in` to `in the`
* Changes `and set to` to `and set it to`