### PR TITLE
Fix support header nesting for Honeycomb in otlp exporter

### DIFF
--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -151,7 +151,7 @@ exporters:
 
 <SubSectionSeparator />
 
-## Support 
+### Support
 
 If you have any trouble using the AWS Distro for OpenTelemetry with Honeycomb, you can reach out to the ADOT support team 
 or directly to the [Honeycomb support page](https://www.honeycomb.io/support/). 


### PR DESCRIPTION
The Honeycomb support header nesting is off by one. This PR attempts to fix it.
![image](https://user-images.githubusercontent.com/58700054/129555948-c4ec7773-3cf4-4b7b-a497-308af3f89b6b.png)
