### PR TITLE
Update ARNs for ADOT August Release

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -62,14 +62,14 @@ public string OriginalFunctionHandler(JObject input, ILambdaContext context)
 This layer includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
   which runs as a Lambda extension.
 
-Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published.
+Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published.
  Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-29-1:1 | Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-33-0:1 | Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
 
 
 ### Enable Tracing

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.2.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-5-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.5.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.5.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -32,14 +32,14 @@ In this section, we consume the Lambda layer for use with Java Lambda Functions.
  This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
   which runs as a Lambda extension.
 
-Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published.
+Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published.
  Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-2-0:2 | Contains [OpenTelemetry for Java v1.2.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.2.0) with [Java Instrumentation v1.2.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.2.0) <br/><br/> Contains the [ADOT Collector for Lambda  v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-5-0:3 | Contains [OpenTelemetry for Java v1.5.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.5.0) with [Java Instrumentation v1.5.2](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.5.2) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -23,13 +23,13 @@ The Lambda layer supports Node.JS v10+ Lambda runtimes. For more information abo
 
 In this section, we consume the Lambda layer for use with Node.JS Lambda Functions. This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector), which runs as a Lambda extension.
 
-Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
+Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-23-0:1 | Contains [OpenTelemetry for JavaScript v0.23.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.23.0) with [Contrib v0.23.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.23.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-24-0:1 | Contains [OpenTelemetry for JavaScript v0.24.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.24.0) with [Contrib v0.24.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.24.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -26,13 +26,13 @@ In this section, we consume the Lambda layer for use with Python Lambda Function
  This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
   which runs as a Lambda extension.
 
-Note: Lambda layers are a rationalized resource, meaning that they can only be used in the Region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
+Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-3-0:1 | Contains [OpenTelemetry for Python v1.3.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0) with [Contrib v0.22b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.22b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-5-0:1 | Contains [OpenTelemetry for Python v1.5.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0) with [Contrib v0.24b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.24b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
Updates the docs with the ARNs of newly published Lambda layers, and corresponding upstream version pointers.

NOTE: Should not be merged until ADOT Collector v0.12.0 is officially released.