### PR TITLE
Correct Java Auto+Python+JS August Release Lambda ARNs

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-5-0:2 | Contains [ADOT Java Auto-Instrumentation Agent v1.5.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.5.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-5-0:3 | Contains [ADOT Java Auto-Instrumentation Agent v1.5.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.5.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-24-0:1 | Contains [OpenTelemetry for JavaScript v0.24.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.24.0) with [Contrib v0.24.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.24.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-24-0:2 | Contains [OpenTelemetry for JavaScript v0.24.0 ](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.24.0) with [Contrib v0.24.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/v0.24.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -32,7 +32,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-5-0:1 | Contains [OpenTelemetry for Python v1.5.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0) with [Contrib v0.24b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.24b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-python38-ver-1-5-0:2 | Contains [OpenTelemetry for Python v1.5.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0) with [Contrib v0.24b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.24b0) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
# Problem
As a follow up to #151, we had a small typo in the Lambda ARNs for some Lambda Layers that we recently released.

# Solution
We can get the correct ARNs from the ones used in the [aws-otel-lambda repo](https://github.com/aws-observability/aws-otel-lambda) for the sample apps and which have passed CI tests:
* [Python Sample App Lambda Layer ARN](https://github.com/aws-observability/aws-otel-lambda/pull/147/files#diff-333af3eace8fac760d868ff40c5f3d0f159f13ef6c3ed15b8b477701f4ee160bR70) is `1-5-0:2`
* [NodeJs Sample App Lambda Layer ARN](https://github.com/aws-observability/aws-otel-lambda/pull/147/files?file-filters%5B%5D=.tf#diff-8bd739774e3c8355552325a22b7f03ffb1205eeaf43e63fd28142ad3e3b22cfcR18) is `0-24-0:2`
* [Java Agent Sample App Lambda Layer ARN](https://github.com/aws-observability/aws-otel-lambda/pull/145/files#diff-321bf731f54ad665e44e9993a2fc8533a8657bdbf7373b0e3bcea6398ba7b68dR3) is `1-5-0:3`

