### PR TITLE
Java Wrapper Lambda Layer 08-31 Release ARN Fix

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-5-0:3 | Contains [OpenTelemetry for Java v1.5.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.5.0) with [Java Instrumentation v1.5.2](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.5.2) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-5-0:2 | Contains [OpenTelemetry for Java v1.5.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.5.0) with [Java Instrumentation v1.5.2](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.5.2) <br/><br/> Contains the [ADOT Collector for Lambda v0.12.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.12.0) |
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
# Description

Fixing Lambda Layer ARN for `java-wrapper` Lambda Layer from the latest August 31st release. Public docs show `:3` but they should say `:2` because that was the [latest one we released](https://github.com/aws-observability/aws-otel-lambda/runs/3469536904?check_suite_focus=true).