### PR TITLE
Small documentation fixes

### DIFF
--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -52,28 +52,26 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:55681
 
 exporters:
   logging:
     loglevel: debug
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:55681
+  awsxray:
 
 #enables output for traces to xray
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, xray]
+      exporters: [logging, awsxray]
 ```
 You can set this via the Lambda console, or via the AWS CLI.
 ```
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
 ```
 
-As an alternative to uploading your collector.yaml file directly with your code, you can zip your file and upload your zip as a seperate Lambda layer.
+As an alternative to uploading your collector.yaml file directly with your code, you can zip your file and upload your zip as a separate Lambda layer.
 You can set this via the Lambda console, or via the AWS CLI.
 ```
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/opt/collector.yaml}

--- a/src/docs/setup/docker-images.mdx
+++ b/src/docs/setup/docker-images.mdx
@@ -38,7 +38,7 @@ The region is where the data will be sent to.
 
 ```yaml
 image: amazon/aws-otel-collector:latest
-command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
+command: ["--config=/etc/otel-agent-config.yaml"]
 environment:
   - AWS_ACCESS_KEY_ID=<to_be_added>
   - AWS_SECRET_ACCESS_KEY=<to_be_added>


### PR DESCRIPTION
# Description

Includes:
* Removing the now deprecated `--log-level` flag
* Fixing the exporters listed on for the Lambda Collector file