### PR TITLE
Update python docs to reference new propagator pkg

### DIFF
--- a/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-auto-instr.mdx
@@ -11,7 +11,7 @@ import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSep
 
 ## Introduction
 
-OpenTelemetry Python supports automatic instrumentation. It automatically produces spans with telemetry data describing the values used by the python frameworks in your application without adding a single line of code. This telemetry data can then be exported to a backend like AWS X-Ray using the ADOT Python `opentelemetry-sdk-extension-aws` package. We also strongly recommend using the `opentelemetry-propagator-aws-xray` package to support propagating the trace context across AWS services.
+OpenTelemetry Python supports automatic instrumentation. It automatically produces spans with telemetry data describing the values used by the python frameworks in your application without adding a single line of code. This telemetry data can then be exported to a backend like AWS X-Ray using the ADOT Python `opentelemetry-sdk-extension-aws` package. We also strongly recommend using the `opentelemetry-propagator-aws-xray` package to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
 
 In this guide, we walk through the steps needed to trace an application with auto-instrumentation.
 

--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -11,7 +11,7 @@ import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSep
 
 ## Introduction
 
-With OpenTelemetry Python manual instrumentation, you configure the OpenTelemetry SDK within your application's code. It automatically produces spans with telemetry data describing the values used by the Python frameworks in your application with only a few lines of code. This telemetry data can then be exported to a backend like AWS X-Ray using the ADOT Python `opentelemetry-sdk-extension-aws` package. We also strongly recommend using the `opentelemetry-propagator-aws-xray` package to support propagating the trace context across AWS services.
+With OpenTelemetry Python manual instrumentation, you configure the OpenTelemetry SDK within your application's code. It automatically produces spans with telemetry data describing the values used by the Python frameworks in your application with only a few lines of code. This telemetry data can then be exported to a backend like AWS X-Ray using the ADOT Python `opentelemetry-sdk-extension-aws` package. We also strongly recommend using the `opentelemetry-propagator-aws-xray` package to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
 
 In this guide, we walk through the steps needed to trace an application with auto instrumentation.
 


### PR DESCRIPTION
# Description

We just released a new package (`opentelemetry-propagator-aws-xray`) on the OTel Python contrib repo.

With the release of the new packages for Python, we want to do a quick follow up and update our documentation to let users know how to instrument with these new packages:
- [opentelemetry-propagator-aws-xray @ 1.0.1](https://pypi.org/project/opentelemetry-propagator-aws-xray/)
- [opentelemetry-sdk-extension-aws @ 2.0.1](https://pypi.org/project/opentelemetry-sdk-extension-aws/)