### PR TITLE
Lambda Layer Update - ARNs for October Release

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -69,7 +69,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-36-0:1 | Contains the [ADOT Collector for Lambda v0.13.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.13.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-collector-ver-0-38-0:1 | Contains the [ADOT Collector for Lambda v0.14.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.14.0)|
 
 
 ### Enable Tracing

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-6-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.6.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.6.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.13.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.13.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-agent-ver-1-7-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.7.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.7.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.14.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.14.0) |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-6-0:1 | Contains [OpenTelemetry for Java v1.6.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.6.0) with [Java Instrumentation v1.6.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.6.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.13.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.13.0) |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-java-wrapper-ver-1-7-0:1 | Contains [OpenTelemetry for Java v1.7.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.7.0) with [Java Instrumentation v1.7.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.6.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.14.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.14.0) |
 
 
 ### Enable auto-instrumentation for your Lambda function

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -29,7 +29,7 @@ Find the supported regions and ARN in the table below for the ARNs to consume.
 
 |Supported   Regions |Lambda layer ARN format| Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-0-25-0:1 | Contains [OpenTelemetry for JavaScript v0.25.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.25.0) with [Lambda instrumentation v0.26.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.26.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.13.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.13.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:\<region\>:901920570463:layer:aws-otel-nodejs-ver-1-0-0:1 | Contains [OpenTelemetry for JavaScript v1.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.0.0) with [Lambda instrumentation v0.26.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.26.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.14.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.14.0)|
 
 
 ### Enable auto-instrumentation for your Lambda function


### PR DESCRIPTION
## Description

Updates the docs with the ARNs of newly published Lambda layers, and corresponding upstream version pointers.

**NOTE**: Should not be merged until Layers are actually released.