### PR TITLE
Improve Prometheus Remote Write Exporter config

### DIFF
--- a/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
+++ b/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
@@ -40,11 +40,6 @@ The Prometheus Receiver monitors each applications deployment using the service 
 - job_name: 'kubernetes-service-endpoints'
   kubernetes_sd_configs:
   - role: endpoints
-  
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   relabel_configs:
   # Example relabel to scrape only endpoints that have
@@ -59,7 +54,7 @@ The Prometheus Receiver monitors each applications deployment using the service 
   #   source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
   #   target_label: __scheme__
   # Example relabel to customize metric path based on endpoints
-  # "prometheus.io/metric_path = <metric path>" annotation.
+  # "prometheus.io/path = <metric path>" annotation.
   # - action: replace
   #   regex: (.+)
   #   source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
@@ -108,10 +103,6 @@ When monitoring pods, we want to watch the pod deployment patterns, total pod in
   sample_limit: 10000
   kubernetes_sd_configs:
   - role: pod
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   relabel_configs:
   # Example relabel to scrape only endpoints that have
   # "prometheus.io/scrape = true" annotation.
@@ -125,7 +116,7 @@ When monitoring pods, we want to watch the pod deployment patterns, total pod in
   #  source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
   #  target_label: __scheme__
   # Example relabel to customize metric path based on endpoints
-  # "prometheus.io/metric_path = <metric path>" annotation.
+  # "prometheus.io/path = <metric path>" annotation.
   # - action: replace
   #  regex: (.+)
   #  source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
@@ -303,10 +294,6 @@ replacing the `__address__`. If we do not want to probe all services, we can spe
     
   kubernetes_sd_configs:
   - role: service
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   
   relabel_configs:
   # Example relabel to probe only some services that have "prometheus.io/should_be_probed = true" annotation
@@ -356,10 +343,6 @@ As setup in `services`, this will also require the Blackbox Exporter.
 
   kubernetes_sd_configs:
   - role: ingress
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   
   relabel_configs:
   # Example relabel to probe only some services that have "prometheus.io/should_be_probed = true" annotation

--- a/src/docs/getting-started/prometheus-remote-write-exporter.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter.mdx
@@ -70,10 +70,6 @@ receivers:
         sample_limit: 10000
         kubernetes_sd_configs:
         - role: endpoints
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 ```
 
 **Note:** To perform Kubernetes service discovery, you will need to set up the proper permissions and RBAC authorization for the service account 


### PR DESCRIPTION
This PR applies least privileges good practices to the Prometheus Remote Write Exporter configuration used in the examples.