### PR TITLE
Fix link pointing to internal website

### DIFF
--- a/src/docs/docker-compose.mdx
+++ b/src/docs/docker-compose.mdx
@@ -1,4 +1,4 @@
-[Run AWS OTel Collector Examples with Docker Setup Steps](https://aws-otel.github.io/docs/setup/docker-images#steps) docker-compose configuration values
+[Run AWS OTel Collector Examples with Docker Setup Steps](https://aws-otel.github.io/docs/setup/docker-images#steps) docker-compose.yaml:
 
 ```yaml
 version: "2"

--- a/src/docs/docker-compose.mdx
+++ b/src/docs/docker-compose.mdx
@@ -1,0 +1,32 @@
+[Run AWS OTel Collector Examples with Docker Setup Steps](https://aws-otel.github.io/docs/setup/docker-images#steps) docker-compose configuration values
+
+```yaml
+version: "2"
+services:
+
+  # AWS Observability Collector
+  aws-ot-collector:
+    image: aottestbed/awscollector:v0.1.11
+    command: ["--log-level=DEBUG"]
+    environment:
+      - AWS_ACCESS_KEY_ID=<to_be_added>
+      - AWS_SECRET_ACCESS_KEY=<to_be_added>
+      - AWS_REGION=<to_be_added>
+    volumes:
+      - ~/.aws:/root/.aws
+    ports:
+      - "1777:1777"   # pprof extension
+      - "55679:55679" # zpages extension
+      - "55680:55680" # OTLP receiver
+      - "13133"       # health_check
+
+  # Metric and Trace Sample Data Generator
+  ot-metric-emitter:
+    image: josephwy/integ-test-emitter:0.9.1
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=aws-ot-collector:55680
+      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=AOCDockerDemo,service.name=AOCDockerDemoService
+      - S3_REGION=us-west-2
+    depends_on:
+      - aws-ot-collector
+```

--- a/src/docs/setup/docker-images.mdx
+++ b/src/docs/setup/docker-images.mdx
@@ -33,7 +33,7 @@ Open and Edit `docker-compose.yaml` file with the expected `AWS_ACCESS_KEY_ID`, 
 The region is where the data will be sent to.
 
 (**Note,** if you can’t access the repo, you can download `docker-compose.yaml` file at
-[here](https://drive.corp.amazon.com/documents/xiami@/AWS-Observability/docker-compose.yaml) and edit
+[here](https://github.com/aws-otel/aws-otel.github.io/blob/main/src/docs/docker-compose.mdx) and edit
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` with the expected values.
 
 ```yaml


### PR DESCRIPTION
This PR is to fix the link pointing to internal website in the Setup Steps of [Run AWS OTel Collector Examples with Docker](https://aws-otel.github.io/docs/setup/docker-images#steps) and create a markdown page for the docker-compose file. 

Issue # 195 