### PR TITLE
Add both grpc and http to example collector config

### DIFF
--- a/src/docs/getting-started/lambda.mdx
+++ b/src/docs/getting-started/lambda.mdx
@@ -46,13 +46,13 @@ This will tell the extension where to find the collector configuration.
 Here is a sample configuration file, collector.yaml in the root directory:
 ```yaml
 #collector.yaml in the root directory
-#Set an environemnt variable 'OPENTELEMETRY_COLLECTOR_CONFIG_FILE' to '/var/task/<path/<to>/<file>'
+#Set an environemnt variable 'OPENTELEMETRY_COLLECTOR_CONFIG_FILE' to '/var/task/collector.yaml'
 
 receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:55681
+      http:
 
 exporters:
   logging:


### PR DESCRIPTION
# Description

Recently, NodeJS changed their default exporter to export http format. Some customers had difficulty using custom collector configs because they only had the grpc receiver (e.g. https://github.com/aws-observability/aws-otel-lambda/issues/176). This doc change should help customers know that they should add both receivers to increase chance of success

[The default collector config](https://github.com/aws-observability/aws-otel-lambda/blob/b2003872eebc35645873485e0fbcfb2ac5ff68cb/adot/collector/config.yaml#L1-L5) we include in the layers already enables both `grpc` and `http` by default.