### PR TITLE
Document Java 8 is not supported for Java Agent Lambda Layer

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -15,7 +15,7 @@ The AWS managed Lambda layer for ADOT Java Auto-instumentation Agent provides a 
 
 ## Requirements
 
-The Lambda layer supports Java 8 and 11 Lambda runtimes. For more information about supported Java versions, see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).
+The Lambda layer supports the Java 11 (Corretto) Lambda runtime. It _does not_ support the Java 8 Lambda runtimes. For more information about supported Java versions, see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/opentelemetry-java).
 
 Note: ADOT Lambda Layer for Java Auto-instrumentation Agent - Automatic instrumentation has a notable impact on startup time on AWS Lambda and you will generally need to use this along with provisioned concurrency and warmup requests to serve production requests without causing timeouts on initial requests while it initializes.
 


### PR DESCRIPTION
## Description

After https://github.com/open-telemetry/opentelemetry-lambda/pull/107 was filed, we confirmed that Java 8 Lambda runtimes are not compatible with the Java Agent Lambda Layers.

We update our documentation to reflect this.

Fixes https://github.com/aws-observability/aws-otel-lambda/issues/199