### PR TITLE
Add ADOT Ruby Documentation

### DIFF
--- a/src/docs/getting-started/ruby-sdk.mdx
+++ b/src/docs/getting-started/ruby-sdk.mdx
@@ -8,7 +8,7 @@ path: '/docs/getting-started/ruby-sdk'
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
 
-# Getting Started with the Ruby SDK on Traces and Metrics Instrumentation
+# Getting Started with the Ruby SDK on Traces Instrumentation
 
 The AWS Distro for OpenTelemetry (ADOT) Ruby refers to some components developed to complement the upstream [OpenTelemetry (OTel) Ruby SDK](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk). Below are links to guides that go over how to configure the relevant components of the OpenTelemetry SDK to send trace data to the AWS X-Ray backend.
 

--- a/src/docs/getting-started/ruby-sdk.mdx
+++ b/src/docs/getting-started/ruby-sdk.mdx
@@ -1,0 +1,23 @@
+---
+title: 'Getting Started with the ADOT Ruby SDK'
+description:
+    OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
+    In this tutorial, we will introduce how to use OpenTelemetry Ruby SDK for traces and metrics instrumentation in the application...
+path: '/docs/getting-started/ruby-sdk'
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+# Getting Started with the Ruby SDK on Traces and Metrics Instrumentation
+
+The AWS Distro for OpenTelemetry (ADOT) Ruby refers to some components developed to complement the upstream [OpenTelemetry (OTel) Ruby SDK](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk). Below are links to guides that go over how to configure the relevant components of the OpenTelemetry SDK to send trace data to the AWS X-Ray backend.
+
+<SectionSeparator />
+
+## Getting Started
+
+* [Manual Instrumentation for Traces with the Ruby SDK](/docs/getting-started/ruby-sdk/trace-manual-instr)
+
+## Sample Code
+
+* [Sample Ruby on Rails App using OpenTelemetry Ruby SDK Manual Instrumentation](https://github.com/aws-observability/aws-otel-ruby/tree/main/sample-apps/manual-instrumentation/ruby-on-rails)

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -77,13 +77,13 @@ For a ruby on rails application, OpenTelemetry Ruby [recommends using a Rails in
 
 In a Ruby on Rails app, you will not need to require packages in your application code because of [autoloading](https://guides.rubyonrails.org/getting_started.html#autoloading). This assumes you are using `bundler` and a Gemfile.
 
-#### From a normal Ruby Program
+#### From other Ruby Programs
 
 This section describes recommended configuration needed for OpenTelemetry X-Ray tracing with X-Ray.
 
 ##### Quick Setup
 
-When you instrument a normal Ruby program, or if you included the gems with the `require: false` option, you will need to "require" the gems distributed by OpenTelemetry manually.
+When you instrument a non-rails Ruby program, or if you included the gems with the `require: false` option, you will need to "require" the gems distributed by OpenTelemetry manually.
 
 Next, the default OpenTelemetry OTLP Exporter with the Batch Processor is a great way to group traces and export them in a way that the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) can receive them.
 
@@ -140,7 +140,8 @@ From above, we learned that configuring OpenTelemetry Ruby required specifying 3
 By default, OpenTelemetry Ruby SDK [is already configured to initialize an OTLP exporter](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-do-i-get-started). The exporter can also be completely [configured using environment variables](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-can-i-configure-the-otlp-exporter).
 
 ```bash
-OTEL_TRACES_EXPORTER=otlp && OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
 The `OTEL_EXPORTER_OTLP_ENDPOINT` value allows you to set the address that the exporter will use to connect to the collector. If unset, the SDK will try to connect to `http://localhost:4318` by default. Note that because the scheme is `http` by default, you have to explicitly set it to be `https` if necessary.
@@ -151,7 +152,7 @@ If the Collector the application will connect to is running with TLS configured,
 
 Next, because the AWS X-Ray ID Generator can only be configured through code, you cannot use an environment variable to select it. The ID Generator must be used at the time OpenTelemetry Ruby SDK is configured.
 
-Finally,tTo allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator to use the AWS X-Ray Propagator.
+Finally, to allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator to use the AWS X-Ray Propagator.
 
 The `OTEL_PROPAGATORS` environment variable can be configured to have the OpenTelemetry Ruby SDK automatically find and initialize the propagator.
 
@@ -169,17 +170,18 @@ You can combine the `xray` propagator with other propagators like `tracecontext`
 
 By default, the OpenTelemetry Ruby SDK follows the parent span's sampling decision if it exists, and samples 100% of incoming requests otherwise. This is known as the `parentbased_always_on` sampler.
 
-To reduce the sampling rate, configure OpenTelemetry Ruby SDK to use the `parentbased_traceidratio` sampler. This can be configured using [the OpenTelemetry Specification defined environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/7b504383f53b02b10f62ef78fa008fdfd18c633e/specification/sdk-environment-variables.md#general-sdk-configuration):
+To reduce the sampling rate, configure OpenTelemetry Ruby SDK to use the `parentbased_traceidratio` sampler. This can be configured using [the OpenTelemetry Specification defined environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/7b504383f53b02b10f62ef78fa008fdfd18c633e/specification/sdk-environment-variables.md#general-sdk-configuration). For instance, to reduce the sampling rate to 10% of requests, set the following environment variables:
 
 
 ```bash
-OTEL_TRACES_SAMPLER=traceidratio && OTEL_TRACES_SAMPLER_ARG=0.10
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.10
 ```
 
 Alternatively, this can be set on the global TracerProvider after the OpenTelemetry Ruby SDK has been configured:
 
 ```ruby
-OpenTelemetry.tracer_provider.sampler = Samplers.trace_id_ratio_based(0.10)
+OpenTelemetry.tracer_provider.sampler = Samplers.parent_based(root: Samplers.trace_id_ratio_based(0.10))
 ```
 
 Currently, OpenTelemetry Ruby does not support centralized sampling.
@@ -309,11 +311,11 @@ tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
 
 tracer.in_span('Root Span', kind: :server) do |root_span|
 
-    p 'Started a root span'
+    p 'Started a root span, this will be a segment in the X-Ray console'
 
     tracer.in_span('Child Span') do |child_span|
 
-        p 'Started a child span'
+        p 'Started a child span, this will be a subsegment in the X-Ray console'
 
         ec2_client = Aws::EC2::Client.new
         result = ec2_client.describe_instances

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -13,7 +13,7 @@ import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSep
 
 With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application with just a few lines of code. OpenTelemetry Ruby then automatically produces trace spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry data can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
 
-In this guide, we walkthrough the steps needed to trace an application with manual instrumentation.
+In this guide, we walk through the steps needed to trace an application with manual instrumentation.
 
 <SectionSeparator />
 

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -11,15 +11,15 @@ import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSep
 
 ## Introduction
 
-With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application's with just a few lines of code. OTel Ruby then automatically produces spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
+With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application with just a few lines of code. OpenTelemetry Ruby then automatically produces spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
 
-In this guide, we walk through the steps needed to trace an application with auto instrumentation.
+In this guide, we walk through the steps needed to trace an application with manual instrumentation.
 
 <SectionSeparator />
 
 ## Requirements
 
-Ruby 2.5 or later is required to run an application using OpenTelemetry according to [the OpenTelemetry Ruby Documentation]((https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#requirements)).
+Ruby 2.5 or later is required to run an application using OpenTelemetry according to [the OpenTelemetry Ruby Documentation](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#requirements).
 
 Note: You’ll also need to have the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) running to export traces to X-Ray.
 
@@ -102,7 +102,7 @@ By default, OpenTelemetry Ruby SDK [is already configured to initialize an OTLP 
 OTEL_TRACES_EXPORTER=otlp
 ```
 
-Otherwise, intiailizing with code is shown below.
+Otherwise, initializing with code is shown below.
 
 To configure for a connection to an ADOT Collector running as a sidecar, we can set up the OTLP Exporter as follows:
 
@@ -265,23 +265,13 @@ gem install opentelemetry-instrumentation-aws_sdk -v '~> 0.2.1'
 
 **NOTE:** Since these instrumentations are not yet stable, we recommend installing it at a pinned version.
 
-Instrumenting the AWS SDK is as easy as initializing the OpenTelemetry Ruby SDK Configurator to use the `OpenTelemetry::Instrumentation::AwsSdk` `Instrumentation` class. This initialization is done as soon as possible in your application so that subsequent calls using the SDK are wrapped by OpenTelemetry. This give OpenTelemetry the chance to record relevant information used by the SDK at the time of your application's call and export the information as spans.
-
-Configuring it explicitly looks can look like the following. We set `suppress_internal_instrumentation` to `true` because we want calls that go into the AWS SDK to be terminal requests without tracing underlying HTTP calls and other things which would make the trace noise-y.
+To instrument requests made to services with the AWS SDK, configure the Ruby SDK as shown. We set `suppress_internal_instrumentation` to `true` because we want calls that go into the AWS SDK to be terminal requests without tracing underlying HTTP calls and other things which would make the trace noise-y.
 
 ```ruby lineNumbers=true
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::AwsSdk', {
     suppress_internal_instrumentation: true
   }
-end
-```
-
-Alternatively, once you've downloaded the `Instrumentation` gem, you can simply tell the OpenTelemetry SDK to trace all `Instrumentation`s including the `OpenTelemetry::Instrumentation::AwsSdk` Instrumentation.
-
-```ruby lineNumbers=true
-OpenTelemetry::SDK.configure do |c|
-  c.use_all()
 end
 ```
 

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Tracing with the AWS Distro for OpenTelemetry Ruby SDK and X-Ray'
 description:
-    OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
+    OpenTelemetry provides several language SDKs to instrument code for collecting telemetry data in the application.
     In this tutorial, we will introduce how to use OpenTelemetry Ruby SDK for traces and metrics instrumentation in the application...
 path: '/docs/getting-started/ruby-sdk/trace-manual-instr'
 ---
@@ -11,9 +11,9 @@ import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSep
 
 ## Introduction
 
-With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application with just a few lines of code. OpenTelemetry Ruby then automatically produces spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
+With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application with just a few lines of code. OpenTelemetry Ruby then automatically produces trace spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry data can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
 
-In this guide, we walk through the steps needed to trace an application with manual instrumentation.
+In this guide, we walkthrough the steps needed to trace an application with manual instrumentation.
 
 <SectionSeparator />
 
@@ -73,7 +73,7 @@ Manual Instrumentation with OpenTelemetry Ruby involves configuring the OpenTele
 
 #### Basic Configuration
 
-This section describes recommended configuration to initialize OpenTelemetry Ruby SDK for tracing with X-Ray.
+This section describes recommended configuration to initialize OpenTelemetry Ruby SDK for tracing with AWS X-Ray.
 
 For a ruby on rails application, [OpenTelemetry Ruby Initialization Documentation](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) recommends placing your configuration code in a Rails initializer. ADOT provides a [working example of such an initializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb).
 
@@ -124,7 +124,7 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-With this, your Ruby application has configured OpenTelemetry Ruby for compatibility with the X-Ray backend service! To automatically trace popular Ruby gems, jump to the next section to learn about [instrumenting with OpenTelemetry Ruby Instrumentations](#instrumenting-an-application).
+With this, your Ruby application has configured OpenTelemetry Ruby for compatibility with the AWS X-Ray service! To automatically trace popular Ruby gems, jump to the next section to learn about [instrumenting with OpenTelemetry Ruby Instrumentations](#instrumenting-an-application).
 
 #### Advanced Configuration
 
@@ -166,6 +166,7 @@ You can combine the `xray` propagator with other propagators like `tracecontext`
 
 By default, the OpenTelemetry Ruby SDK follows the parent span's sampling decision if it exists, and samples 100% of incoming requests otherwise. This is known as the `parentbased_always_on` sampler.
 
+#### Reduce Sampling Rate
 To reduce the sampling rate, configure OpenTelemetry Ruby SDK to use the `parentbased_traceidratio` sampler. This can be configured using [the OpenTelemetry Specification defined environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/7b504383f53b02b10f62ef78fa008fdfd18c633e/specification/sdk-environment-variables.md#general-sdk-configuration). For instance, to reduce the sampling rate to 10% of requests, set the following environment variables:
 
 
@@ -366,4 +367,4 @@ See [OpenTelemetry Ruby's own documentation on adding attributes to spans](https
 
 ## Sample Application
 
-See a [sample Ruby on Rails App using OpenTelemetry Ruby SDK Manual Instrumentation](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails).
+See the [sample Ruby on Rails App using OpenTelemetry Ruby SDK Manual Instrumentation](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails).

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -69,13 +69,27 @@ $ gem install opentelemetry-instrumentation-faraday -v '~> 0.19' \
 
 ### Sending Traces to AWS X-Ray
 
-For a ruby on rails application, OpenTelemetry Ruby [recommends using a Rails initializer](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) to configure the OpenTelemetry Ruby SDK. ADOT provides a [working example of such an intializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb). A [railtie](https://api.rubyonrails.org/classes/Rails/Railtie.html) could also be used for this purpose.
+Manual Instrumentation with OpenTelemetry Ruby involves configuring the OpenTelemetry Ruby SDK. Below we discuss where configuration should take place based on the Ruby program you are instrumenting.
+
+#### From a Rails Application
+
+For a ruby on rails application, OpenTelemetry Ruby [recommends using a Rails initializer](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) to configure the OpenTelemetry Ruby SDK. ADOT provides a [working example of such an intializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb).
 
 In a Ruby on Rails app, you will not need to require packages in your application code because of [autoloading](https://guides.rubyonrails.org/getting_started.html#autoloading). This assumes you are using `bundler` and a Gemfile.
 
-However, if you tracing a normal Ruby program, or have included gems with the `, require: false` option, the code below shows step by step how to configure the OpenTelemetry Ruby SDK in any normal Ruby program.
+#### From a normal Ruby Program
 
-First, you will need to "require" the gems you use for your application and the ones used by OpenTelemetry manually. 
+This section describes recommended configuration needed for OpenTelemetry X-Ray tracing with X-Ray.
+
+##### Quick Setup
+
+When you instrument a normal Ruby program, or if you included the gems with the `require: false` option, you will need to "require" the gems distributed by OpenTelemetry manually.
+
+Next, the default OpenTelemetry OTLP Exporter with the Batch Processor is a great way to group traces and export them in a way that the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) can receive them.
+
+Finally, using the X-Ray ID Generator is **required** to make your OpenTelemetry traces appear in X-Ray, while the X-Ray Propagator is **strongly recommended** in order to inject and extract the X-Ray Tracing header for downstream requests made by your application.
+
+Putting this all together, we come up with the following:
 
 ```ruby lineNumbers=true
 # Basic packages for your application
@@ -89,53 +103,55 @@ require 'opentelemetry-sdk'
 
 # Import the gem containing the AWS X-Ray for OTel Ruby ID Generator and propagator
 require 'opentelemetry-propagator-xray'
+
+# Configure OpenTelmetry Ruby SDK
+OpenTelemetry::SDK.configure do |c|
+  # Set the service name to identify your application in the X-Ray backend service map
+  c.service_name = 'aws-otel-manual-rails-sample'
+
+  c.span_processors = [
+      # Use the BatchSpanProcessor to send traces in groups instead of one at a time
+      Trace::Export::BatchSpanProcessor.new(
+          # Use the default OLTP Exporter to send traces to the ADOT Collector
+          OpenTelemetry::Exporter::OTLP::Exporter.new(
+            # The ADOT Collector is running as a sidecar and listening on port 4318
+            endpoint="http://localhost:4318"
+          )
+      )
+    ]
+
+  # The X-Ray ID Generator generates spans with X-Ray backend compliant IDs
+  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
+
+  # The X-Ray Propagator injects the X-Ray Tracing Header into downstream calls
+  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
+end
 ```
 
-Next, configure the Global Tracer Provider. This involves configuring
-* which Exporter to use to export to the ADOT Collector
+With this, your Ruby application has configured OpenTelemetry Ruby to trace for the X-Ray backend service! To automatically trace popular Ruby gems, jump to the next section to learn about [instrumenting with OpenTelemetry Ruby Instrumentations](#instrumenting-an-application).
+
+##### Advanced Setup
+
+From above, we learned that configuring OpenTelemetry Ruby required specifying 3 core steps
+* which Exporter to use to export to the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector)
 * which ID Generator to use to generate Trace IDs
-* which Instrumentation Gems to use to automatically trace calls to other gems
+* which Propagator to use to propagate Trace Context to downstream calls
 
 By default, OpenTelemetry Ruby SDK [is already configured to initialize an OTLP exporter](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-do-i-get-started). The exporter can also be completely [configured using environment variables](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-can-i-configure-the-otlp-exporter).
 
 ```bash
-OTEL_TRACES_EXPORTER=otlp
+OTEL_TRACES_EXPORTER=otlp && OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
-Otherwise, initializing with code is shown below.
-
-To configure for a connection to an ADOT Collector running as a sidecar, we can set up the OTLP Exporter as follows:
-
-```ruby lineNumbers=true
-# Sends generated traces in the OTLP format to an ADOT Collector running on port 4318
-otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint="http://localhost:4318")
-# Processes traces in batches as opposed to immediately one after the other
-span_processor = Trace::Export::BatchSpanProcessor.new(otlp_exporter)
-```
-
-The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If unset, the SDK will try to connect to `http://localhost:4318` by default. Note that because the scheme is `http` by default, you have to explicitly set it to be `https` if necessary.
+The `OTEL_EXPORTER_OTLP_ENDPOINT` value allows you to set the address that the exporter will use to connect to the collector. If unset, the SDK will try to connect to `http://localhost:4318` by default. Note that because the scheme is `http` by default, you have to explicitly set it to be `https` if necessary.
 
 If the Collector the application will connect to is running without TLS configured, the `http` scheme is used to disable client transport security for the OTLP exporter's connection. This option should never be used in production, non-sidecar deployments.
 
 If the Collector the application will connect to is running with TLS configured, the `https` scheme and the `certificate_file=/path/to/cert.pem` argument should be used to give a path to credentials that allow the application to establish a secure connection for the app's exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates.
 
-With the exporter created, initialize OpenTelemetry Ruby SDK to use it:
+Next, because the AWS X-Ray ID Generator can only be configured through code, you cannot use an environment variable to select it. The ID Generator must be used at the time OpenTelemetry Ruby SDK is configured.
 
-```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.span_processors = [span_processor]
-end
-```
-
-Next, because the AWS X-Ray backend service requires compliant Trace IDs, create an instance of the ID generator during initialization as follows:
-
-```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
-end
-```
-
-To allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator to use the AWS X-Ray Propagator.
+Finally,tTo allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator to use the AWS X-Ray Propagator.
 
 The `OTEL_PROPAGATORS` environment variable can be configured to have the OpenTelemetry Ruby SDK automatically find and initialize the propagator.
 
@@ -143,37 +159,36 @@ The `OTEL_PROPAGATORS` environment variable can be configured to have the OpenTe
 OTEL_PROPAGATORS=xray
 ```
 
-On the other hand, you can set the global propagator in code as follows.
+The propagator should be configured as soon as possible in your application's code so that subsequent downstream requests get the OpenTelemetry trace context injected into its HTTP headers. This is what allows your traces to be connected and for you to see a complete Service Graph in the X-Ray console.
 
-```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
-end
+Likewise, configuring the X-Ray Propagator means incoming requests to your application can parse out an OpenTelemetry Trace context and use the same Trace ID to pick up tracing where the upstream service left off.
+
+You can combine the `xray` propagator with other propagators like `tracecontext` and `b3` just fine, but it is recommended you put `xray` last because the propagator later in the list will override previous propagators.
+
+### Configuring Sampling
+
+By default, the OpenTelemetry Ruby SDK follows the parent span's sampling decision if it exists, and samples 100% of incoming requests otherwise. This is known as the `parentbased_always_on` sampler.
+
+To reduce the sampling rate, configure OpenTelemetry Ruby SDK to use the `parentbased_traceidratio` sampler. This can be configured using [the OpenTelemetry Specification defined environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/7b504383f53b02b10f62ef78fa008fdfd18c633e/specification/sdk-environment-variables.md#general-sdk-configuration):
+
+
+```bash
+OTEL_TRACES_SAMPLER=traceidratio && OTEL_TRACES_SAMPLER_ARG=0.10
 ```
 
-Either way, the propagator should be configured as soon as possible in your application's code.
-
-Putting this all together we have something like the following:
+Alternatively, this can be set on the global TracerProvider after the OpenTelemetry Ruby SDK has been configured:
 
 ```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.service_name = 'aws-otel-manual-rails-sample'
-
-  c.span_processors = [
-      Trace::Export::BatchSpanProcessor.new(
-          OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint="http://localhost:4318")
-      )
-    ]
-  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
-  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
-end
+OpenTelemetry.tracer_provider.sampler = Samplers.trace_id_ratio_based(0.10)
 ```
 
-### Using the AWS resource Detectors
+Currently, OpenTelemetry Ruby does not support centralized sampling.
+
+<!-- ### Using the AWS resource Detectors
 
 TODO: Update this section when ADOT Ruby Resource Detectors have been contributed upstream. They will most likely be found [alongside other 3rd party Resource Detectors on the OpenTelmetry Ruby GitHub Repository](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/resource_detectors/lib/opentelemetry/resource/detectors)
 
-<!-- The ADOT Ruby SDK supports automatically detecting and recording metadata from resources such as EC2, Elastic Beanstalk, ECS, and EKS.
+The ADOT Ruby SDK supports automatically detecting and recording metadata from resources such as EC2, Elastic Beanstalk, ECS, and EKS.
 
 For example, if tracing with OpenTelemetry Ruby on an AWS EC2 instance, you can automatically populate `resource` attributes by initializing the OpenTelemetry Ruby SDK `TraceProvider` to use the `AwsEc2ResourceDetector`:
 
@@ -292,9 +307,12 @@ require 'opentelemetry-api'
 # Get a tracer from the Global Tracer Provider
 tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
 
-tracer.in_span('Root Span') do |root_span|
+tracer.in_span('Root Span', kind: :server) do |root_span|
+
     p 'Started a root span'
+
     tracer.in_span('Child Span') do |child_span|
+
         p 'Started a child span'
 
         ec2_client = Aws::EC2::Client.new
@@ -331,6 +349,7 @@ tracer.in_span('Root Span',
         ]
     },
     kind: :server) do |root_span|
+
     p 'Started a root span'
 
     span.set_attribute('my_attribute', 'foo')

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -69,25 +69,21 @@ $ gem install opentelemetry-instrumentation-faraday -v '~> 0.19' \
 
 ### Sending Traces to AWS X-Ray
 
-Manual Instrumentation with OpenTelemetry Ruby involves configuring the OpenTelemetry Ruby SDK. Below we discuss where configuration should take place based on the Ruby program you are instrumenting.
+Manual Instrumentation with OpenTelemetry Ruby involves configuring the OpenTelemetry Ruby SDK. Below we discuss different methods you have for configuring the OpenTelemetry Ruby SDK.
 
-#### From a Rails Application
+#### Basic Configuration
 
-For a ruby on rails application, OpenTelemetry Ruby [recommends using a Rails initializer](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) to configure the OpenTelemetry Ruby SDK. ADOT provides a [working example of such an intializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb).
+This section describes recommended configuration to initialize OpenTelemetry Ruby SDK for tracing with X-Ray.
 
-In a Ruby on Rails app, you will not need to require packages in your application code because of [autoloading](https://guides.rubyonrails.org/getting_started.html#autoloading). This assumes you are using `bundler` and a Gemfile.
+For a ruby on rails application, [OpenTelemetry Ruby Initialization Documentation](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) recommends placing your configuration code in a Rails initializer. ADOT provides a [working example of such an initializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb).
 
-#### From other Ruby Programs
+In a Ruby on Rails app, you will not need to require packages in your application code because of [autoloading](https://guides.rubyonrails.org/getting_started.html#autoloading). This assumes you are using `bundler` and a Gemfile. Otherwise, if you included the gems with the `require: false` option or you are not using `bundler`, you will need to "require" the gems distributed by OpenTelemetry manually.
 
-This section describes recommended configuration needed for OpenTelemetry X-Ray tracing with X-Ray.
+For all manually instrumented Ruby programs, you must use the `OpenTelemetry::SDK.configure` method below to configure the OpenTelemetry Ruby SDK.
 
-##### Quick Setup
+The default OpenTelemetry OTLP Exporter with the Batch Processor is a great way to group traces and export them in a way that the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) can receive them.
 
-When you instrument a non-rails Ruby program, or if you included the gems with the `require: false` option, you will need to "require" the gems distributed by OpenTelemetry manually.
-
-Next, the default OpenTelemetry OTLP Exporter with the Batch Processor is a great way to group traces and export them in a way that the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) can receive them.
-
-Finally, using the X-Ray ID Generator is **required** to make your OpenTelemetry traces appear in X-Ray, while the X-Ray Propagator is **strongly recommended** in order to inject and extract the X-Ray Tracing header for downstream requests made by your application.
+Additionally, using the X-Ray ID Generator is **required** to make your OpenTelemetry traces appear in X-Ray, while the X-Ray Propagator is **strongly recommended** in order to inject and extract the X-Ray Tracing header for downstream requests made by your application.
 
 Putting this all together, we come up with the following:
 
@@ -128,9 +124,9 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-With this, your Ruby application has configured OpenTelemetry Ruby to trace for the X-Ray backend service! To automatically trace popular Ruby gems, jump to the next section to learn about [instrumenting with OpenTelemetry Ruby Instrumentations](#instrumenting-an-application).
+With this, your Ruby application has configured OpenTelemetry Ruby for compatibility with the X-Ray backend service! To automatically trace popular Ruby gems, jump to the next section to learn about [instrumenting with OpenTelemetry Ruby Instrumentations](#instrumenting-an-application).
 
-##### Advanced Setup
+#### Advanced Configuration
 
 From above, we learned that configuring OpenTelemetry Ruby required specifying 3 core steps
 * which Exporter to use to export to the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector)
@@ -156,8 +152,8 @@ Finally, to allow the span context to propagate downstream when the application 
 
 The `OTEL_PROPAGATORS` environment variable can be configured to have the OpenTelemetry Ruby SDK automatically find and initialize the propagator.
 
-```
-OTEL_PROPAGATORS=xray
+```bash
+export OTEL_PROPAGATORS=xray
 ```
 
 The propagator should be configured as soon as possible in your application's code so that subsequent downstream requests get the OpenTelemetry trace context injected into its HTTP headers. This is what allows your traces to be connected and for you to see a complete Service Graph in the X-Ray console.
@@ -180,7 +176,7 @@ export OTEL_TRACES_SAMPLER_ARG=0.10
 
 Alternatively, this can be set on the global TracerProvider after the OpenTelemetry Ruby SDK has been configured:
 
-```ruby
+```ruby lineNumbers=true
 OpenTelemetry.tracer_provider.sampler = Samplers.parent_based(root: Samplers.trace_id_ratio_based(0.10))
 ```
 
@@ -194,7 +190,7 @@ The ADOT Ruby SDK supports automatically detecting and recording metadata from r
 
 For example, if tracing with OpenTelemetry Ruby on an AWS EC2 instance, you can automatically populate `resource` attributes by initializing the OpenTelemetry Ruby SDK `TraceProvider` to use the `AwsEc2ResourceDetector`:
 
-```ruby
+```ruby lineNumbers=true
 OpenTelemetry::SDK.configure do |c|
   c.service_name = 'aws-otel-manual-rails-sample'
 
@@ -209,8 +205,8 @@ end
 
 By default, OpenTelemetry Ruby SDK logs at the `info` level. Its level can be configured using the `OTEL_LOG_LEVEL` environment variable.
 
-```
-OTEL_LOG_LEVEL=debug
+```bash
+export OTEL_LOG_LEVEL=debug
 ```
 
 Separate from OpenTelemetry, you can use code and set the Base Logger to modify the logging level throughput your application.
@@ -274,10 +270,10 @@ If you are using `bundler`, you can include it in in the Gemfile.
 gem 'opentelemetry-instrumentation-aws_sdk', '~> 0.2.1'
 ```
 
-Otherwise you can install it directly.
+Otherwise you can install it directly using your shell.
 
 ```bash
-gem install opentelemetry-instrumentation-aws_sdk -v '~> 0.2.1'
+$ gem install opentelemetry-instrumentation-aws_sdk -v '~> 0.2.1'
 ```
 
 **NOTE:** Since these instrumentations are not yet stable, we recommend installing it at a pinned version.

--- a/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/ruby-sdk/trace-manual-instr.mdx
@@ -1,0 +1,362 @@
+---
+title: 'Tracing with the AWS Distro for OpenTelemetry Ruby SDK and X-Ray'
+description:
+    OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
+    In this tutorial, we will introduce how to use OpenTelemetry Ruby SDK for traces and metrics instrumentation in the application...
+path: '/docs/getting-started/ruby-sdk/trace-manual-instr'
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
+
+## Introduction
+
+With OpenTelemetry Ruby manual instrumentation, you configure the OpenTelemetry SDK within your application's with just a few lines of code. OTel Ruby then automatically produces spans with telemetry data describing the values used by the Ruby gems in your application. This telemetry can then be exported to a backend like AWS X-Ray using the `OpenTelemetry::Propagator::XRay::IDGenerator` found in the ADOT Ruby `opentelemetry-propagator-xray` gem. We also strongly recommend using the `OpenTelemetry::Propagator::XRay::TextMapPropagator` propagator found in the same gem to support propagating the trace context across AWS services. This propagator handles the extraction and injecting of the [AWS X-Ray Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) for requests from or to remote services.
+
+In this guide, we walk through the steps needed to trace an application with auto instrumentation.
+
+<SectionSeparator />
+
+## Requirements
+
+Ruby 2.5 or later is required to run an application using OpenTelemetry according to [the OpenTelemetry Ruby Documentation]((https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#requirements)).
+
+Note: You’ll also need to have the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) running to export traces to X-Ray.
+
+<SectionSeparator />
+
+## Installation
+
+If you are using [bundler](https://bundler.io/), include the following gems in your Ruby application's Gemfile:
+
+```ruby
+gem 'opentelemetry-exporter-otlp'
+gem 'opentelemetry-sdk'
+
+gem 'opentelemetry-propagator-xray'
+```
+
+Or, install them directly:
+
+```bash
+$ gem install opentelemetry-exporter-otlp \
+              opentelemetry-sdk \
+              opentelemetry-propagator-xray
+```
+
+Next, we'll use `bundler` to install gems that automatically instrument your application code.
+
+OpenTelemetry Ruby distributes many gems that instrument well-known Ruby dependencies. You need to install the relevant instrumentation package for every dependency you want to generate traces for. To see supported gems, check out the [OpenTelemetry Registry](https://opentelemetry.io/registry/?s=ruby&component=instrumentation).
+
+For example, use `bundler` and add the follow instrumentation gems to your Gemfile:
+
+
+```ruby
+gem 'opentelemetry-instrumentation-faraday', '~> 0.19'
+gem 'opentelemetry-instrumentation-rails', '~> 0.20'
+```
+
+Or, install them directly:
+
+```bash
+$ gem install opentelemetry-instrumentation-faraday -v '~> 0.19' \
+              opentelemetry-instrumentation-rails -v '~> 0.20'
+```
+
+<SectionSeparator />
+
+## Setting up the Global Tracer
+
+### Sending Traces to AWS X-Ray
+
+For a ruby on rails application, OpenTelemetry Ruby [recommends using a Rails initializer](https://opentelemetry.io/docs/instrumentation/ruby/getting_started/#initialization) to configure the OpenTelemetry Ruby SDK. ADOT provides a [working example of such an intializer in our sample app repo](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails/config/initializers/opentelemetry.rb). A [railtie](https://api.rubyonrails.org/classes/Rails/Railtie.html) could also be used for this purpose.
+
+In a Ruby on Rails app, you will not need to require packages in your application code because of [autoloading](https://guides.rubyonrails.org/getting_started.html#autoloading). This assumes you are using `bundler` and a Gemfile.
+
+However, if you tracing a normal Ruby program, or have included gems with the `, require: false` option, the code below shows step by step how to configure the OpenTelemetry Ruby SDK in any normal Ruby program.
+
+First, you will need to "require" the gems you use for your application and the ones used by OpenTelemetry manually. 
+
+```ruby lineNumbers=true
+# Basic packages for your application
+require 'aws-sdk'
+require 'faraday'
+
+# Add imports for OTel components into the application
+require 'opentelemetry-api'
+require 'opentelemetry-exporter-otlp'
+require 'opentelemetry-sdk'
+
+# Import the gem containing the AWS X-Ray for OTel Ruby ID Generator and propagator
+require 'opentelemetry-propagator-xray'
+```
+
+Next, configure the Global Tracer Provider. This involves configuring
+* which Exporter to use to export to the ADOT Collector
+* which ID Generator to use to generate Trace IDs
+* which Instrumentation Gems to use to automatically trace calls to other gems
+
+By default, OpenTelemetry Ruby SDK [is already configured to initialize an OTLP exporter](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-do-i-get-started). The exporter can also be completely [configured using environment variables](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp#how-can-i-configure-the-otlp-exporter).
+
+```bash
+OTEL_TRACES_EXPORTER=otlp
+```
+
+Otherwise, intiailizing with code is shown below.
+
+To configure for a connection to an ADOT Collector running as a sidecar, we can set up the OTLP Exporter as follows:
+
+```ruby lineNumbers=true
+# Sends generated traces in the OTLP format to an ADOT Collector running on port 4318
+otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint="http://localhost:4318")
+# Processes traces in batches as opposed to immediately one after the other
+span_processor = Trace::Export::BatchSpanProcessor.new(otlp_exporter)
+```
+
+The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If unset, the SDK will try to connect to `http://localhost:4318` by default. Note that because the scheme is `http` by default, you have to explicitly set it to be `https` if necessary.
+
+If the Collector the application will connect to is running without TLS configured, the `http` scheme is used to disable client transport security for the OTLP exporter's connection. This option should never be used in production, non-sidecar deployments.
+
+If the Collector the application will connect to is running with TLS configured, the `https` scheme and the `certificate_file=/path/to/cert.pem` argument should be used to give a path to credentials that allow the application to establish a secure connection for the app's exporter. The credentials at this path should be the public certificate of the collector, or one of its root certificates.
+
+With the exporter created, initialize OpenTelemetry Ruby SDK to use it:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.span_processors = [span_processor]
+end
+```
+
+Next, because the AWS X-Ray backend service requires compliant Trace IDs, create an instance of the ID generator during initialization as follows:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
+end
+```
+
+To allow the span context to propagate downstream when the application makes calls to external services, configure the global propagator to use the AWS X-Ray Propagator.
+
+The `OTEL_PROPAGATORS` environment variable can be configured to have the OpenTelemetry Ruby SDK automatically find and initialize the propagator.
+
+```
+OTEL_PROPAGATORS=xray
+```
+
+On the other hand, you can set the global propagator in code as follows.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
+end
+```
+
+Either way, the propagator should be configured as soon as possible in your application's code.
+
+Putting this all together we have something like the following:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'aws-otel-manual-rails-sample'
+
+  c.span_processors = [
+      Trace::Export::BatchSpanProcessor.new(
+          OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint="http://localhost:4318")
+      )
+    ]
+  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
+  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
+end
+```
+
+### Using the AWS resource Detectors
+
+TODO: Update this section when ADOT Ruby Resource Detectors have been contributed upstream. They will most likely be found [alongside other 3rd party Resource Detectors on the OpenTelmetry Ruby GitHub Repository](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/resource_detectors/lib/opentelemetry/resource/detectors)
+
+<!-- The ADOT Ruby SDK supports automatically detecting and recording metadata from resources such as EC2, Elastic Beanstalk, ECS, and EKS.
+
+For example, if tracing with OpenTelemetry Ruby on an AWS EC2 instance, you can automatically populate `resource` attributes by initializing the OpenTelemetry Ruby SDK `TraceProvider` to use the `AwsEc2ResourceDetector`:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'aws-otel-manual-rails-sample'
+
+  c.span_processors = [span_processor]
+  c.id_generator = OpenTelemetry::Propagator::XRay::IDGenerator
+  c.propagators = [OpenTelemetry::Propagator::XRay::TextMapPropagator.new]
+  c.resource = OpenTelemetry::XRay::AwsEc2ResourceDetector.new.merge(Resources::Resource.default),
+end
+``` -->
+
+### Debug Logging
+
+By default, OpenTelemetry Ruby SDK logs at the `info` level. Its level can be configured using the `OTEL_LOG_LEVEL` environment variable.
+
+```
+OTEL_LOG_LEVEL=debug
+```
+
+Separate from OpenTelemetry, you can use code and set the Base Logger to modify the logging level throughput your application.
+
+```ruby lineNumbers=true
+ActiveJob::Base.logger = Logger.new(STDOUT, level=Logger::DEBUG)
+```
+
+Additionally, you can create your own logger that logs at the log level you set.
+
+```ruby lineNumbers=true
+require 'logger'
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::WARN
+
+logger.warn("This log message is visible!")
+logger.debug("This one is not.")
+```
+
+<SectionSeparator />
+
+## Instrumenting an Application
+
+**Warning: Some instrumentations are not yet stable and the attributes they collect are subject to change until the instrumentation reaches 1.0 stability. It is recommended to pin a specific version of an instrumentation**
+
+OpenTelemetry provides a wide range of instrumentations for popular Ruby libraries such as Rails, Sinatra, Faraday, the AwsSdk and many more. Instrumenting a library means that every time the library is used to make or handle a request, that library call is automatically wrapped with a populated span contain the relevant values that were used. Web framework, downstream HTTP, SQL, gRPC, and other requests can all be recorded using OpenTelemetry.
+
+A full list of supported instrumentation packages and configuration instructions can be found on the [instrumentation folder of the OpenTelemetry Ruby repo](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation).
+
+To enable tracing of the calls made by your package dependencies, you need to include the relevant `Instrumentation` classes during OpenTelemetry Ruby SDK initialization. `Instrumentation`s have individual initialization configurability, so refer to the `Instrumentation`'s documentation for configuration details.
+
+```ruby lineNumbers=true
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Rails'
+  c.use 'OpenTelemetry::Instrumentation::Rack'
+  c.use 'OpenTelemetry::Instrumentation::ActionPack'
+  c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
+  c.use 'OpenTelemetry::Instrumentation::ActionView'
+  # c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
+
+  c.use 'OpenTelemetry::Instrumentation::Faraday'
+end
+```
+
+Alternatively, you can enable all `Instrumentation`s which have been downloaded for this Ruby project. Not that you still need to download the `Instrumentation` gem for it to be initialized in the OpenTelemetry Ruby SDK.
+
+```ruby lineNumbers=true
+OpenTelemetry::SDK.configure do |c|
+  c.use_all()
+end
+```
+
+### Instrumenting the AWS SDK
+
+To instrument the AWS Ruby SDK and its dependencies, install the `opentelemetry-instrumentation-aws_sdk` [OpenTelemetry Ruby Instrumentation gem for the AWS SDK](https://rubygems.org/gems/opentelemetry-instrumentation-aws_sdk).
+
+If you are using `bundler`, you can include it in in the Gemfile.
+
+```ruby
+gem 'opentelemetry-instrumentation-aws_sdk', '~> 0.2.1'
+```
+
+Otherwise you can install it directly.
+
+```bash
+gem install opentelemetry-instrumentation-aws_sdk -v '~> 0.2.1'
+```
+
+**NOTE:** Since these instrumentations are not yet stable, we recommend installing it at a pinned version.
+
+Instrumenting the AWS SDK is as easy as initializing the OpenTelemetry Ruby SDK Configurator to use the `OpenTelemetry::Instrumentation::AwsSdk` `Instrumentation` class. This initialization is done as soon as possible in your application so that subsequent calls using the SDK are wrapped by OpenTelemetry. This give OpenTelemetry the chance to record relevant information used by the SDK at the time of your application's call and export the information as spans.
+
+Configuring it explicitly looks can look like the following. We set `suppress_internal_instrumentation` to `true` because we want calls that go into the AWS SDK to be terminal requests without tracing underlying HTTP calls and other things which would make the trace noise-y.
+
+```ruby lineNumbers=true
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::AwsSdk', {
+    suppress_internal_instrumentation: true
+  }
+end
+```
+
+Alternatively, once you've downloaded the `Instrumentation` gem, you can simply tell the OpenTelemetry SDK to trace all `Instrumentation`s including the `OpenTelemetry::Instrumentation::AwsSdk` Instrumentation.
+
+```ruby lineNumbers=true
+OpenTelemetry::SDK.configure do |c|
+  c.use_all()
+end
+```
+
+For more information refer to [the upstream documentation for OpenTelemetry Ruby AWS SDK Instrumentation](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/aws_sdk).
+
+<SectionSeparator />
+
+## Custom Instrumentation
+
+### Creating Custom Spans
+
+You can use custom spans to monitor the performance of internal activities that are not captured by instrumentation libraries. Note that only spans of kind `Server` are converted into X-Ray segments, all other spans are converted into X-Ray subsegments. For more on segments and subsegments, see the [AWS X-Ray developer guide](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-segments).
+
+```ruby lineNumbers=true
+require 'aws-sdk'
+require 'opentelemetry-api'
+
+# Get a tracer from the Global Tracer Provider
+tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
+
+tracer.in_span('Root Span') do |root_span|
+    p 'Started a root span'
+    tracer.in_span('Child Span') do |child_span|
+        p 'Started a child span'
+
+        ec2_client = Aws::EC2::Client.new
+        result = ec2_client.describe_instances
+
+        p "EC2 Describe Instances: #{result}"
+
+        p '<h1>Good job! Traces recorded!</h1>'
+    end
+end
+```
+
+See [OpenTelemetry Ruby's own documentation on creating spans manually](https://opentelemetry.io/docs/instrumentation/ruby/manual_instrumentation/#creating-new-spans) for more information.
+
+### Adding custom attributes
+
+You can also add custom key-value pairs as attributes onto your spans. Attributes are converted to metadata by default. If you [configure your collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/7bf2266a025425993a233f66c77a0810ab11a78b/exporter/awsxrayexporter#exporter-configuration), you can convert some or all of the attributes to annotations. To read more about X-Ray annotations and metadata see the [AWS X-Ray Developer Guide](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-annotations).
+
+One way to add custom attributes is as follows:
+
+```ruby lineNumbers=true
+require 'opentelemetry-api'
+
+# Get a tracer from the Global Tracer Provider
+tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
+
+tracer.in_span('Root Span',
+    attributes: {
+        'hello' => 'world',
+        'some.number' => 1024,
+        'tags' => [
+            'bug',
+            'enhancement'
+        ]
+    },
+    kind: :server) do |root_span|
+    p 'Started a root span'
+
+    span.set_attribute('my_attribute', 'foo')
+    span.set_attribute('more_items', ['bar', 'baz'])
+
+    span.add_attributes({
+        "yet.another.attribute" => "attribute value",
+        "and.another.one" => "has a value"
+    })
+end
+```
+
+See [OpenTelemetry Ruby's own documentation on adding attributes to spans](https://opentelemetry.io/docs/instrumentation/ruby/manual_instrumentation/#attributes) for more information.
+
+<SectionSeparator />
+
+## Sample Application
+
+See a [sample Ruby on Rails App using OpenTelemetry Ruby SDK Manual Instrumentation](https://github.com/aws-observability/aws-otel-ruby/blob/main/sample-apps/manual-instrumentation/ruby-on-rails).


### PR DESCRIPTION
## Description

Adds ADOT Ruby documentation for how to instrument OpenTelemetry Ruby for compatibility with the AWS X-Ray Service.

Follow the templates for ADOT documentation here: https://github.com/willarmiros/aws-otel-docs/tree/main/templates
