### PR TITLE
Add ADOT Ruby Docs link in sidebar

### DIFF
--- a/src/config/sideBarData.js
+++ b/src/config/sideBarData.js
@@ -51,6 +51,7 @@ export const sideBarData = [
         {label: "Java", link: "/docs/getting-started/java-sdk"},
         {label: "JavaScript", link: "/docs/getting-started/javascript-sdk"},
         {label: "Python", link: "/docs/getting-started/python-sdk"},
+        {label: "Ruby", link: "/docs/getting-started/ruby-sdk"},
         {label: ".NET", link: "/docs/getting-started/dotnet-sdk"},
         {label: "k8s Operator", link: "/docs/getting-started/operator"},
         {label: "Lambda", link: "/docs/getting-started/lambda"},


### PR DESCRIPTION
## Description

Follow up to #224, we added the ADOT Ruby documentation but we should also add it to the sidebar so customers can find it easily.