### PR TITLE
Lambda Release March 2022: Blog Post release announcement for ADOT lambda layers

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -10,10 +10,10 @@ blogs:
     author: "Pavan Sai Vasireddy and Nathaniel Ruiz Nowell"
     date: "07-Mar-2022"
     body:
-      "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.17.0 now supports ARM64 architecture."
+      "ADOT Lambda Layers distribute ADOT Collector v0.17.0 with new layers supporting ARM64 Lambda functions"
     link: "/docs/lambdalayermarch"
 
-  - title: "AWS Distro for OpenTelemetry 0.17 is now available"
+  - title: "AWS Distro for OpenTelemetry 0.17 is now available with updated Lambda layers"
     author: "Alolita Sharma and Bryan Aguilar"
     date: "02-Mar-2022"
     body:

--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,7 +6,14 @@ description:
 path: /blog
 
 blogs:
-  - title: "AWS Distro for OpenTelemetry 0.17 is now available with updated Lambda layers"
+  - title: "AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 architecture. "
+    author: "Pavan Sai Vasireddy and Nathaniel Ruiz Nowell"
+    date: "07-Mar-2022"
+    body:
+      "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.17.0 now supports ARM64 architecture."
+    link: "/docs/lambdalayermarch"
+
+  - title: "AWS Distro for OpenTelemetry 0.17 is now available"
     author: "Alolita Sharma and Bryan Aguilar"
     date: "02-Mar-2022"
     body:

--- a/src/content/blogs/lambdalayermarch.mdx
+++ b/src/content/blogs/lambdalayermarch.mdx
@@ -1,0 +1,32 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.17.0  are released and now support ARM64 architecture'
+description:
+    This blog post is the release announcement ADOT lambda layers
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 regions in the following regions.
+Asia Pacific (Mumbai), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), Europe (Frankfurt), Europe (Ireland), Europe (London), US East (N. Virginia), US East (Ohio), and US West (Oregon).
+
+<SectionSeparator />
+
+**Release Highlights**
+
+* Python3.8 layer [aws-otel-python38-ver-1-9-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python v1.9.1 with the AWS Python Extension v2.0.1
+* Nodejs layer [aws-otel-nodejs-ver-1-0-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core v1.0.1 with AWS Lambda Instrumentation v0.28.1
+* Java-Wrapper layer [aws-otel-java-wrapper-ver-1-11-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java v1.11.1
+* Java-Agent layer [aws-otel-java-agent-ver-1-11-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS OpenTelemetry Java instrumentation v1.10.1
+* Collector layer [aws-otel-collector-ver-0-45-0] contains ADOT Collector v0.17.0. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+
+**Download**
+
+To Learn more about AWS Distro for Open Telemetry Lambda site [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). 
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status 
+earlier this year by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about 
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the 
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).

--- a/src/content/blogs/lambdalayermarch.mdx
+++ b/src/content/blogs/lambdalayermarch.mdx
@@ -8,7 +8,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 
 <SectionSeparator />
 
-AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 regions in the following regions:
+AWS Distro for OpenTelemetry Lambda Layers now support ARM64 AWS regions in the following regions:
 * Asia Pacific (Mumbai)
 * Asia Pacific (Singapore)
 * Asia Pacific (Sydney)
@@ -32,10 +32,10 @@ AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 regions in the fol
 
 **Download**
 
-To Learn more about AWS Distro for Open Telemetry Lambda site [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+Learn more about AWS Distro for Open Telemetry Lambda support [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are made upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
 
-We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). 
-The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status 
-earlier this year by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about 
-[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the 
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status earlier this year by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). 
+
+More blog posts about 
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) can be found on the 
 [AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).

--- a/src/content/blogs/lambdalayermarch.mdx
+++ b/src/content/blogs/lambdalayermarch.mdx
@@ -1,25 +1,34 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.17.0  are released and now support ARM64 architecture'
+title: 'AWS Distro for OpenTelemetry Lambda Layers that contain ADOT Collector v0.17.0 are released and now support ARM64 architecture'
 description:
-    This blog post is the release announcement ADOT lambda layers
+    March 2022 release announcement for ADOT Lambda layers
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
 
 <SectionSeparator />
 
-AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 regions in the following regions.
-Asia Pacific (Mumbai), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), Europe (Frankfurt), Europe (Ireland), Europe (London), US East (N. Virginia), US East (Ohio), and US West (Oregon).
+AWS Distro for OpenTelemetry Lambda Layers now supports ARM64 regions in the following regions:
+* Asia Pacific (Mumbai)
+* Asia Pacific (Singapore)
+* Asia Pacific (Sydney)
+* Asia Pacific (Tokyo)
+* Europe (Frankfurt)
+* Europe (Ireland)
+* Europe (London)
+* US East (N. Virginia)
+* US East (Ohio)
+* US West (Oregon)
 
 <SectionSeparator />
 
 **Release Highlights**
 
-* Python3.8 layer [aws-otel-python38-ver-1-9-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python v1.9.1 with the AWS Python Extension v2.0.1
-* Nodejs layer [aws-otel-nodejs-ver-1-0-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core v1.0.1 with AWS Lambda Instrumentation v0.28.1
-* Java-Wrapper layer [aws-otel-java-wrapper-ver-1-11-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java v1.11.1
-* Java-Agent layer [aws-otel-java-agent-ver-1-11-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS OpenTelemetry Java instrumentation v1.10.1
-* Collector layer [aws-otel-collector-ver-0-45-0] contains ADOT Collector v0.17.0. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+* Python3.8 layer [**aws-otel-python38-<amd64|arm64>-ver-1-9-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python v1.9.1 with the AWS Python Extension v2.0.1
+* Nodejs layer [**aws-otel-nodejs-<amd64|arm64>-ver-1-0-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core v1.0.1 with AWS Lambda Instrumentation v0.29
+* Java-Wrapper layer [**aws-otel-java-wrapper-<amd64|arm64>-ver-1-11-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java v1.11.1
+* Java-Agent layer [**aws-otel-java-agent-<amd64|arm64>-ver-1-11-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS OpenTelemetry Java instrumentation v1.11.1
+* Collector layer **aws-otel-collector-<amd64|arm64>-ver-0-45-0** contains ADOT Collector v0.17.0. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
 
 **Download**
 


### PR DESCRIPTION
This PR adds blog post for release announcement of ADOT Lambda layers