### PR TITLE
Add v0.16.1 blog post

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -21,6 +21,14 @@ blogs:
       from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery."
     link: "/docs/v0.17.0"
 
+  - title: "AWS Distro for OpenTelemetry 0.16.1 is now available"
+    author: "Alolita Sharma and Bryan Aguilar"
+    date: "02-Mar-2022"
+    body:
+      "AWS Distro for OpenTelemetry 0.16.1 is now available. You can download the latest AWS Distro for OpenTelemetry Collector image
+      from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery."
+    link: "/docs/v0.16.1"
+
   - title: "AWS Distro for OpenTelemetry 0.16 is now available with updated Lambda layers"
     author: "Alolita Sharma and Raman Aulakh"
     date: "31-Jan-2022"

--- a/src/content/blogs/v0.16.1.mdx
+++ b/src/content/blogs/v0.16.1.mdx
@@ -1,0 +1,34 @@
+---
+title: 'AWS Distro for OpenTelemetry v0.16.1'
+description:
+    This Blog post is the release announcement for ADOT v0.16.1
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) v0.16.1 is now available. You can download the latest [ADOT Collector image](https://gallery.ecr.aws/aws-observability/aws-otel-collector) from the [Amazon Elastic Container Registry (Amazon ECR)](https://aws.amazon.com/ecr/) Public Gallery.
+
+<SectionSeparator />
+
+# Notice
+
+We are aware of a potential issue in the Go standard library prior to version 1.17.7 [CVE-2022-23806](https://nvd.nist.gov/vuln/detail/CVE-2022-23806) used by the AWS Distribution for Open Telemetry (ADOT) Collector prior to version 0.16.1.
+
+We have prepared a new release of the ADOT Collector, 0.16.1 using Go 1.17.7. There are no functional changes from ADOT Collector v0.16.0. We recommend that customers update their ADOT Collector to at least v0.16.1 at the earliest opportunity. See https://aws-otel.github.io/docs/getting-started/collector for information on deploying the ADOT Collector.
+Reference: https://nvd.nist.gov/vuln/detail/CVE-2022-23806
+
+# Release Highlights
+
+* Recompile with Go 1.17.7 to mitigate CVE-2022-23806. ADOT users are recommended to update to this latest release to avoid any related vulnerabilities.
+
+Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-collector/releases). All code changes are upstream in the respective OpenTelemetry project components.
+
+# Download
+
+Detailed technical documentation is available on the [ADOT developer site](https://aws-otel.github.io/), and you can [download the distribution](https://aws-otel.github.io/download) from [GitHub](https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.16.0). You can also download the latest [ADOT Collector image](https://gallery.ecr.aws/aws-observability/aws-otel-collector) from the [Amazon Elastic Container Registry (Amazon ECR)](https://aws.amazon.com/ecr/) Public Gallery.
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution, check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html). Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status earlier this year by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about [AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the [AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021.


### PR DESCRIPTION
Adds a blog post for patch `v0.16.1` to notify users of security vulnerability mitigation. 