### PR TITLE
Update component table to include `prometheusremotewriteexporter` and `sigv4authextension`

### DIFF
--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -26,7 +26,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter` | zpagesextension        |
 | `awsxrayreceiver`               | memorylimiter                 | loggingexporter                    | `ecsobserver`          |
-| `statsdreceiver`                | tailsamplingprocessor         | otlpexporter                       |                        |
+| `statsdreceiver`                | tailsamplingprocessor         | otlpexporter                       | `sigv4authextension`   |
 | zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       |                        |
 | jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   |                        |
 | `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |
@@ -36,5 +36,6 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 |                                 |                               | sapmexporter                       |                        |
 |                                 |                               | signalfxexporter                   |                        |
 |                                 |                               | logzioexporter                     |                        |
+|                                 |                               | prometheusremotewriteexporter      |                        |
 
-Note: Components in italics are AWS developed
+Note: Highlighted components are AWS developed. Also note that the `awsprometheusremotewriteexporter` will be removed at some point after v0.19.0 of the ADOT Collector. Users who want to send metrics to Amazon Managed Service for Prometheus will need to instead use the [Prometheus Remote Write Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md) along with the [Sigv4 Authenticator Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/sigv4authextension/README.md) to achieve the same result.


### PR DESCRIPTION
See https://github.com/aws-observability/aws-otel-collector/pull/1066 for the corresponding PR in aws-observability/aws-otel-collector. The previous PR for this, #270, was accidentally merged then subsequently reverted. 
NOTE: Do not merge this until the next release