### PR TITLE
Update docs for x-ray remote sampling and container insights

### DIFF
--- a/src/docs/getting-started/container-insights.mdx
+++ b/src/docs/getting-started/container-insights.mdx
@@ -31,8 +31,6 @@ we have enhanced the [ADOT Collector](https://github.com/aws-observability/aws-o
 CloudWatch Container Insights collects metrics for many resources such as CPU, memory, disk, and network.
 It also provides diagnostic information such as container restart failures.
 The metrics are aggregated at the cluster, node, pod, task, and service level as CloudWatch metrics.
-To collect the infrastructure metrics, ADOT Collector uses the [AWS Container Insights Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver)
-and the [CloudWatch embedded metric format Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter).
 
 The following platforms are supported:
 

--- a/src/docs/getting-started/java-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/trace-auto-instr.mdx
@@ -60,7 +60,9 @@ For example, to set the random sampling rate for creating traces, you can set th
 
 The ADOT Java Auto-Instrumentation Agent can be configured to use [X-Ray remote sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html)
 by setting the environment variable `OTEL_TRACES_SAMPLER=xray`. You will also need to [configure the OpenTelemetry collector](/docs/getting-started/remote-sampling)
-to allow the application to fetch sampling configuration. By default the sampler sends requests to `http://localhost:2000`. By setting `OTEL_TRACES_SAMPLER_ARG` environment variable you can change the endpoint the sampler talks with when getting sampling configuration from AWS X-Ray Console. For example setting `OTEL_TRACES_SAMPLER_ARG=endpoint=localhost:4000` would configure the sampler to communicate with `localhost:4000`.
+to allow the application to fetch sampling configuration. By default the sampler sends requests to `http://localhost:2000`. By setting `OTEL_TRACES_SAMPLER_ARG` 
+environment variable you can change the endpoint the sampler talks with when getting sampling configuration from AWS X-Ray Console. For example setting 
+`OTEL_TRACES_SAMPLER_ARG=endpoint=http://localhost:4000` would configure the sampler to communicate with `http://localhost:4000`.
 ### Running the agent in Docker
 
 If your application is packaged in Docker, the easiest way to run with the agent is to use the


### PR DESCRIPTION
Fixes #252 #235 

Updates endpoint for x-ray to use `http://`

Removes sentence that could cause confusion on container insight metrics collection. Users should now refer to the platform specific links for information regarding container insights. 