### PR TITLE
Update dev guide

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -8,7 +8,7 @@
 ## Development Setup
 
 1. Clone this repository onto your local machine
-2. [Download and Set up Gatsby Environment](https://www.gatsbyjs.com/tutorial/part-zero/) Note: When using Gatsby, you will need downgrade your version of Node to 16 prior to installation of gatsby-cli. You can do this via `nvm use 16`.
+2. [Download and Set up Gatsby Environment](https://www.gatsbyjs.com/tutorial/part-zero/).
 3. Open up the project using your preferred code editor
 4. Install the required node modules for this project.
     ```


### PR DESCRIPTION
Updated dev guide to remove node version for installing node.

Link to issue: https://github.com/aws-otel/aws-otel.github.io/issues/236

Tested it locally.