### PR TITLE
Remove reference to ADOT Collector in Operator doc

### DIFF
--- a/src/docs/getting-started/operator.mdx
+++ b/src/docs/getting-started/operator.mdx
@@ -9,7 +9,7 @@ import operatorImg1 from "assets/img/docs/gettingStarted/operator/img1.png"
 import operatorImg2 from "assets/img/docs/gettingStarted/operator/img2.png"
 
 Welcome to the AWS Distro for OpenTelemetry (ADOT) getting started guide for the OpenTelemetry Operator. This guide covers the OpenTelemetry Operator,
-how to install it in your Amazon Elastic Kubernetes Service (Amazon EKS) cluster using a Helm chart and how to configure the ADOT
+how to install it in your Amazon Elastic Kubernetes Service (Amazon EKS) cluster using a Helm chart and how to configure the
 Collector as Kubernetes Custom Resource (CR), which will be managed by the OpenTelemetry Operator. Before reading this guide, we recommend
 you to have an understanding of the basics of [Helm](http://helm.sh/), the package manager for Kubernetes.
 


### PR DESCRIPTION
OpenTelemetry operator does not deploy ADOT Collector by default. 