### PR TITLE
Fix Component Table

### DIFF
--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -26,7 +26,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter` | zpagesextension        |
 | `awsxrayreceiver`               | memorylimiter                 | loggingexporter                    | `ecsobserver`          |
-| `statsdreceiver`                | `metricsgenerationprocessor`  | otlpexporter                       | `awsproxy`             |
+| statsdreceiver                  | `metricsgenerationprocessor`  | otlpexporter                       | `awsproxy`             |
 | zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       | ballastextention       |
 | jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   |                        |
 | `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |

--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -26,15 +26,14 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter` | zpagesextension        |
 | `awsxrayreceiver`               | memorylimiter                 | loggingexporter                    | `ecsobserver`          |
-| `statsdreceiver`                | tailsamplingprocessor         | otlpexporter                       |                        |
-| zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       |                        |
+| `statsdreceiver`                | `metricsgenerationprocessor`  | otlpexporter                       | `awsproxy`             |
+| zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       | ballastextention       |
 | jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   |                        |
 | `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |
 |                                 | metricstransformprocessor     | datadogexporter                    |                        |
 |                                 | resourcedetectionprocessor    | dynatraceexporter                  |                        |
-|                                 |                               | newrelicexporter                   |                        |
-|                                 |                               | sapmexporter                       |                        |
-|                                 |                               | signalfxexporter                   |                        |
+|                                 | cumulativetodeltaprocessor    | sapmexporter                       |                        |
+|                                 | deltatorateprocessor          | signalfxexporter                   |                        |
 |                                 |                               | logzioexporter                     |                        |
 
 Note: Components in italics are AWS developed


### PR DESCRIPTION
This PR addresses #266 and does the following:
- Add `metricsgenerationprocessor`, `cumulativetodeltaprocessor`, and `deltatorateprocessor` to Processors
- Remove `tailsamplingprocessor` from Processors, as it is currently not included in the ADOT Collector
- Remove `newrelicexporter` from Exporters, as it is currently not included in the ADOT Collector
- Add `awsproxy` and `ballastextention` to Extensions