### PR TITLE
Fixed dependency

### DIFF
--- a/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
@@ -236,7 +236,7 @@ The `opentelemetry-instrumentation-aws-sdk-2.2` artifact provides instrumentatio
 dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.5.0-alpha"))\
 
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-aws-sdk-2.2")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2")
 
     ...
 }


### PR DESCRIPTION
This dependency appears to be wrong and does not exist on maven central.
implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2") seems to be the intended one.