### PR TITLE
Update Package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6717,6 +6717,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/contentful-management/node_modules/type-fest": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+      "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/contentful-sdk-core": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.10.4.tgz",
@@ -27121,11 +27132,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.8.0.tgz",
-      "integrity": "sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=12.20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -34092,6 +34105,13 @@
         "fast-copy": "^2.1.0",
         "lodash.isplainobject": "^4.0.6",
         "type-fest": "^2.5.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+          "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw=="
+        }
       }
     },
     "contentful-sdk-core": {
@@ -49367,9 +49387,11 @@
       }
     },
     "type-fest": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.8.0.tgz",
-      "integrity": "sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",


### PR DESCRIPTION
This PR updates `package-lock.json`, this possibly eliminates the [error](https://github.com/aws-otel/aws-otel.github.io/runs/6711373858?check_suite_focus=true#step:6:26) in the PR build while executing command `npm ci`. The error seems to be straight-forward to update the `package-lock.json`.