### PR TITLE
[datadog] Remove usage of deprecated options

### DIFF
--- a/src/docs/partners/datadog.mdx
+++ b/src/docs/partners/datadog.mdx
@@ -42,14 +42,14 @@ processors:
 
 ## Specifying resource attributes
 
-On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using [the language's SDK](https://opentelemetry.io/docs/). As a fall-back, you can also configure hostname (optionally), environment, service name, and service version at the collector level for [unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging) by following the [example configuration file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml). If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
+On each OpenTelemetry-instrumented application, set the resource attributes `development.environment`, `service.name`, and `service.version` using [the language's SDK](https://opentelemetry.io/docs/). As a fall-back, you can also configure hostname (optionally) at the collector level for [unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging) by following the [example configuration file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/datadogexporter/example/config.yaml). If you don't specify the hostname explicitly, the exporter attempts to get an automatic default by checking the following sources in order, falling back to the next one if the current one is unavailable or invalid:
 
 <!--- 1. Hostname set by another OpenTelemetry component -->
 1. Manually set the hostname in configuration
-1. EC2 non-default hostname (if in an EC2 instance)
-1. EC2 instance id (if in an EC2 instance)
-1. Fully qualified domain name
-1. Operating system hostname
+2. Cloud integration API hostname
+3. Kubernetes hostname
+4. Fully qualified domain name
+5. Operating system hostname
 
 ## Configuring the pipeline
 
@@ -79,12 +79,10 @@ processors:
 exporters:
   datadog/api:
     hostname: i-0e123a456a123456a
-    env: prod
-    service: web-store
-    version: 7.1.0
 
-    tags:
-      - geo.country:fr
+    host_metadata:
+      tags:
+        - geo.country:fr
 
     api:
       key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -107,10 +105,10 @@ receivers:
 exporters:
   datadog/api:
     hostname: i-0e123a456a123456a
-    env: prod
 
-    tags:
-      - geo.country:fr
+    host_metadata:
+      tags:
+        - geo.country:fr
 
     api:
       key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -127,7 +125,7 @@ Supply the relative path to this configuration file when you start the collector
 
 ## Resources
 
-For additional information about the Datadog exporter and environment specific onboarding instructions, visit the [Datadog OpenTelemetry Collector](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter) documentation or the [`open-telemetry` Github repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/datadogexporter).
+For additional information about the Datadog exporter and environment specific onboarding instructions, visit the [Datadog OpenTelemetry Collector](https://docs.datadoghq.com/tracing/setup_overview/open_standards/otel_collector_datadog_exporter/) documentation or the [`open-telemetry` Github repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter).
 
 ## Support
 


### PR DESCRIPTION
Update Datadog exporter documentation to:

1. Remove references to deprecated configuration options (see open-telemetry/opentelemetry-collector-contrib/issues/8372 for more details on the deprecated options)
2. Update links to official Datadog documentation
3. Update explanation of hostname used to account for improvements (see open-telemetry/opentelemetry-collector-contrib/issues/10424 for more details)