### PR TITLE
Enable Syntax highlight to all languages in the documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "node-fetch": "^3.2.6",
         "nouislider": "^13.1.1",
         "npm": "^8.13.2",
+        "prismjs": "^1.28.0",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-datetime": "^2.16.3",
@@ -24182,6 +24183,14 @@
       "integrity": "sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==",
       "peerDependencies": {
         "react": ">=0.14.9"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/probe-image-size": {
@@ -49396,6 +49405,11 @@
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz",
       "integrity": "sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==",
       "requires": {}
+    },
+    "prismjs": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
     },
     "probe-image-size": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node-fetch": "^3.2.6",
     "nouislider": "^13.1.1",
     "npm": "^8.13.2",
+    "prismjs": "^1.28.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-datetime": "^2.16.3",

--- a/src/@rocketseat/gatsby-theme-docs/styles/global.js
+++ b/src/@rocketseat/gatsby-theme-docs/styles/global.js
@@ -2,6 +2,18 @@ import React from 'react';
 import { Global, css } from '@emotion/react';
 import { useTheme } from '@emotion/react';
 
+// Add syntax highlight for languages not enabled by default
+// https://github.com/FormidableLabs/prism-react-renderer#faq
+import Prism from "prism-react-renderer/prism";
+
+(typeof global !== "undefined" ? global : window).Prism = Prism;
+
+require("prismjs/components/prism-kotlin");
+require("prismjs/components/prism-java");
+require("prismjs/components/prism-ruby");
+require("prismjs/components/prism-csharp")
+
+
 export default function GlobalStyle() {
   const theme = useTheme();
 
@@ -271,6 +283,22 @@ export default function GlobalStyle() {
 
         pre[class~='language-bash']::before {
           content: 'bash';
+        }
+
+        pre[class~='language-java']::before {
+          content: 'Java';
+        }
+
+        pre[class~='language-csharp']::before {
+          content: 'C#';
+        }
+
+        pre[class~='language-ruby']::before {
+          content: 'Ruby';
+        }
+
+        pre[class~='language-kotlin']::before {
+          content: 'Kotlin';
         }
 
         pre[class~='language-yaml']::before,

--- a/src/docs/getting-started/java-sdk/trace-auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/trace-auto-instr.mdx
@@ -88,7 +88,7 @@ version of this artifact can not be newer than the version of the agent. Notably
 artifact, any usage of it will be disabled by the agent.
 
 ##### For Gradle:
-```java lineNumbers=true
+```kotlin lineNumbers=true
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api:1.6.0")
 }

--- a/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/trace-manual-instr.mdx
@@ -35,7 +35,7 @@ Several components provide the functionality for using OpenTelemetry SDK with X-
 to align dependency versions for non-contrib components.
 
 ##### For Gradle:
-```java lineNumbers=true
+```kotlin lineNumbers=true
 dependencies {
     api(platform("io.opentelemetry:opentelemetry-bom:1.6.0"))
 
@@ -108,7 +108,7 @@ OpenTelemetrySdk.builder()
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     W3CTraceContextPropagator.getInstance(), AwsXrayPropagator.getInstance())))
-        
+
         // This provides basic configuration of a TracerProvider which generates X-Ray compliant IDs
         .setTracerProvider(
             SdkTracerProvider.builder()
@@ -125,7 +125,7 @@ AWS resource detectors for enriching traces with AWS infrastructure information 
 artifact.
 
 ##### For Gradle:
-```java lineNumbers=true
+```kotlin lineNumbers=true
 dependencies {
     implementation("io.opentelemetry:opentelemetry-sdk-extension-aws")
 }
@@ -179,7 +179,7 @@ the `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha` B
 library instrumentation. When using this, do not include `opentelemetry-bom`.
 
 ##### For Gradle:
-```java lineNumbers=true
+```kotlin lineNumbers=true
 dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.6.0-alpha"))
 


### PR DESCRIPTION
Enable Syntax highlight to all languages used in the documentation.

This has to be done because we use `rocketseat/gatsby-theme-docs`, which uses `prism-react-renderer` which only enable an arbitrary set of languages by default. 

https://github.com/FormidableLabs/prism-react-renderer#faq

This will make the website experience uniform across all languages.