### PR TITLE
fix(docs): outdated class names

### DIFF
--- a/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/python-sdk/trace-manual-instr.mdx
@@ -64,10 +64,10 @@ import json
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 # Import the AWS X-Ray for OTel Python IDs Generator into the application.
-from opentelemetry.sdk.extension.aws.trace import AwsXRayIdsGenerator
+from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
 ```
 
 Next, configure the Global Tracer Provider to export to the ADOT Collector. The configuration of your SDK exporter depends on how you wish to connect with your configured ADOT Collector.
@@ -78,9 +78,9 @@ Connecting to an ADOT Collector running as a sidecar, we can set up the TracerPr
 # Sends generated traces in the OTLP format to an ADOT Collector running on port 4317
 otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4317")
 # Processes traces in batches as opposed to immediately one after the other
-span_processor = BatchExportSpanProcessor(otlp_exporter)
+span_processor = BatchSpanProcessor(otlp_exporter)
 # Configures the Global Tracer Provider
-trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor, ids_generator=AwsXRayIdsGenerator()))
+trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor, ids_generator=AwsXRayIdGenerator()))
 ```
 
 The `endpoint=` argument allows you to set the address that the exporter will use to connect to the collector. If unset, the SDK will try to connect to `http://localhost:4317` by default. Note that because the scheme is `http` by default, you have to explicitly set it to be `https` if necessary.


### PR DESCRIPTION
Solve [this issue](https://github.com/aws-observability/aws-otel-community/issues/81)

[Tracing with ADOT Python SDK and X-Ray documentation](https://aws-otel.github.io/docs/getting-started/python-sdk/trace-manual-instr) uses some old classes.

[Sending Traces to AWS X-Ray](https://aws-otel.github.io/docs/getting-started/python-sdk/trace-manual-instr#sending-traces-to-aws-x-ray) should be like the following because `BatchExportSpanProcessor` is renamed to `BatchSpanProcessor` at [this PR](https://github.com/open-telemetry/opentelemetry-python/pull/1656) and `AwsXRayIdsGenerator` is renamed to `AwsXRayIdGenerator` at [this PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/350).
```
from opentelemetry.sdk.trace.export import BatchSpanProcessor
from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
# Sends generated traces in the OTLP format to an ADOT Collector running on port 4317
otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4317")
# Processes traces in batches as opposed to immediately one after the other
span_processor = BatchSpanProcessor(otlp_exporter)
# Configures the Global Tracer Provider
trace.set_tracer_provider(TracerProvider(active_span_processor=span_processor, ids_generator=AwsXRayIdGenerator()))
```

