### PR TITLE
Update website for ADOT Collector release v0.21.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,14 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry v0.21.0 is now available"
+    author: "Eric Hsueh"
+    date: "30-August-2022"
+    body:
+      "AWS Distro for OpenTelemetry v0.21.0 is now available. You can download the latest AWS Distro for OpenTelemetry Collector image
+      from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.21.0"
+    
   - title: "AWS Distro for OpenTelemetry Lambda Layers are now available with ADOT Collector v0.20.0"
     author: "Pavan Sai Vasireddy"
     date: "01-AUG-2022"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.21.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.21.0.mdx
@@ -17,7 +17,7 @@ You can download the latest [ADOT Collector image](https://gallery.ecr.aws/aws-o
 **Release Highlights**
 
 * OpenTelemetry Collector [v0.58.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.58.0)
-* OpenTelemetry Collector [v0.57.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.57.0)
+* OpenTelemetry Collector [v0.57.2](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.57.2)
 
 Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-collector/releases). 
 All code changes are upstream in the respective OpenTelemetry project components.

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.21.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.21.0.mdx
@@ -1,0 +1,48 @@
+---
+title: 'AWS Distro for OpenTelemetry v0.21.0'
+description:
+    This blog post is the release announcement for ADOT v0.21.0
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) v0.21.0 is now available. 
+You can download the latest [ADOT Collector image](https://gallery.ecr.aws/aws-observability/aws-otel-collector) from the 
+[Amazon Elastic Container Registry (Amazon ECR)](https://aws.amazon.com/ecr/) Public Gallery.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+* OpenTelemetry Collector [v0.58.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.58.0)
+* OpenTelemetry Collector [v0.57.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.57.0)
+
+Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-collector/releases). 
+All code changes are upstream in the respective OpenTelemetry project components.
+
+*Important note:* The `awsprometheusremotewrite` exporter has been removed in v0.21.0. Instead, modify your configurations to
+use the `prometheusremotewrite` exporter with the `sigv4auth` extension. Please refer to the [documentation](https://aws-otel.github.io/docs/sigv4) 
+for instructions on how to do so.
+
+**Download**
+
+Detailed technical documentation is available on the [ADOT developer site](https://aws-otel.github.io/), 
+and you can [download the distribution](https://aws-otel.github.io/download) from 
+[GitHub](https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.21.0). 
+You can also download the latest [ADOT Collector image](https://gallery.ecr.aws/aws-observability/aws-otel-collector) 
+from the [Amazon Elastic Container Registry (Amazon ECR)](https://aws.amazon.com/ecr/) Public Gallery.
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution, 
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html). 
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any 
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). 
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status 
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the 
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced 
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021 
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.

--- a/src/content/Downloads/downloads.yaml
+++ b/src/content/Downloads/downloads.yaml
@@ -1,3 +1,10 @@
+- version: 'AWS Distro for OpenTelemetry Collector Version 0.21.0'
+  releaseDate: 'August-30-2022'
+  license: 'Apache-2.0'
+  releaseNotesLink: 'https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.21.0'
+  documentationLink: 'https://github.com/aws-observability/aws-otel-collector/blob/v0.21.0/README.md'
+  downloadLink: 'https://gallery.ecr.aws/aws-observability/aws-otel-collector'
+
 - version: 'AWS Distro for OpenTelemetry Collector Version 0.20.0'
   releaseDate: 'July-27-2022'
   license: 'Apache-2.0'


### PR DESCRIPTION
This PR updates the ADOT Collector download page with version 0.21.0, and also adds a blog post for 0.21.0 as well