### PR TITLE
Remove references to the `awsprometheusremotewrite` exporter

### DIFF
--- a/src/docs/getting-started/adot-eks-add-on/config-advanced.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/config-advanced.mdx
@@ -44,6 +44,11 @@ spec:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8888'
   config: |
+    extensions:
+      sigv4auth:
+        region: <YOUR_AWS_REGION>
+        service: "aps"
+
     receivers:    
       prometheus:
         config:
@@ -307,18 +312,18 @@ spec:
         timeout: 60s   
 
     exporters:
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         endpoint: <YOUR_REMOTE_WRITE_ENDPOINT>
-        aws_auth:
-          region: <YOUR_AWS_REGION>
-          service: "aps"
+        auth:
+          authenticator: sigv4auth
 
     service:
+      extensions: [sigv4auth]
       pipelines:
         metrics:
           receivers: [prometheus]
           processors: [batch/metrics]
-          exporters: [awsprometheusremotewrite]
+          exporters: [prometheusremotewrite]
 ```
 
 </details>

--- a/src/docs/getting-started/adot-eks-add-on/config-amp.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/config-amp.mdx
@@ -12,11 +12,11 @@ path: '/docs/getting-started/adot-eks-add-on/config-amp'
 
 ## Collector Configuration
 
-The Collector configuration below is set up to receive Prometheus metrics and export to Amazon Managed Prometheus. Note that the Prometheus receiver is meant to be a drop-in replacement for a Prometheus server and is capable of scraping metrics from microservices instrumented with the [Prometheus client library](https://prometheus.io/docs/instrumenting/clientlibs/). It also supports the full set of [Prometheus configuration](https://github.com/prometheus/prometheus/blob/v2.28.1/docs/configuration/configuration.md#scrape_config). The AWS Prometheus Remote Write Exporter employs the [remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) feature and sends metrics data to an existing Amazon Managed Prometheus workspace for long term storage. Note that the file below is also hosted [here](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/operator/collector-config-amp.yaml). Save this into a file called `collector-config-amp.yaml` and execute the command 
+The Collector configuration below is set up to receive Prometheus metrics and export to Amazon Managed Prometheus. Note that the Prometheus receiver is meant to be a drop-in replacement for a Prometheus server and is capable of scraping metrics from microservices instrumented with the [Prometheus client library](https://prometheus.io/docs/instrumenting/clientlibs/). It also supports the full set of [Prometheus configuration](https://github.com/prometheus/prometheus/blob/v2.28.1/docs/configuration/configuration.md#scrape_config). The Prometheus Remote Write Exporter employs the [remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) feature and sends metrics data to an existing Amazon Managed Prometheus workspace for long term storage. Note that the file below is also hosted [here](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/operator/collector-config-amp.yaml). Save this into a file called `collector-config-amp.yaml` and execute the command 
 ```console
 kubectl apply -f collector-config-amp.yaml
 ```
-to deploy your Collector. Make sure to replace `<YOUR_REMOTE_WRITE_ENDPOINT>` and `<YOUR_AWS_REGION>` in the `awsprometheusremoterwite` exporter config, as per your own target environment. Note that a `ClusterRole` and `ClusterRoleBinding` will also be created, which provide necessary permissions for the `prometheus` receiver during service discovery.
+to deploy your Collector. Make sure to replace `<YOUR_REMOTE_WRITE_ENDPOINT>` and `<YOUR_AWS_REGION>` in the `prometheusremoterwite` exporter config, as per your own target environment. Note that a `ClusterRole` and `ClusterRoleBinding` will also be created, which provide necessary permissions for the `prometheus` receiver during service discovery.
 
 <details>
   <summary>
@@ -26,7 +26,7 @@ to deploy your Collector. Make sure to replace `<YOUR_REMOTE_WRITE_ENDPOINT>` an
 ```yaml
 #
 # OpenTelemetry Collector configuration
-# Metrics pipeline with Prometheus Receiver and AWS Remote Write Exporter sending metrics to Amazon Managed Prometheus
+# Metrics pipeline with Prometheus Receiver and Prometheus Remote Write Exporter sending metrics to Amazon Managed Prometheus
 #
 ---
 apiVersion: opentelemetry.io/v1alpha1
@@ -40,6 +40,11 @@ spec:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8888'
   config: |
+    extensions:
+      sigv4auth:
+        region: <YOUR_AWS_REGION>
+        service: "aps"
+
     receivers:
       #
       # Scrape configuration for the Prometheus Receiver
@@ -325,18 +330,18 @@ spec:
         timeout: 60s         
 
     exporters:
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         endpoint: <YOUR_REMOTE_WRITE_ENDPOINT>
-        aws_auth:
-          region: <YOUR_AWS_REGION>
-          service: "aps"
+        auth:
+          authenticator: sigv4auth
 
     service:
+      extensions: [sigv4auth]
       pipelines:   
         metrics:
           receivers: [prometheus]
           processors: [batch/metrics]
-          exporters: [awsprometheusremotewrite]
+          exporters: [prometheusremotewrite]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/src/docs/getting-started/adot-eks-add-on/config-amp.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/config-amp.mdx
@@ -16,7 +16,7 @@ The Collector configuration below is set up to receive Prometheus metrics and ex
 ```console
 kubectl apply -f collector-config-amp.yaml
 ```
-to deploy your Collector. Make sure to replace `<YOUR_REMOTE_WRITE_ENDPOINT>` and `<YOUR_AWS_REGION>` in the `prometheusremoterwite` exporter config, as per your own target environment. Note that a `ClusterRole` and `ClusterRoleBinding` will also be created, which provide necessary permissions for the `prometheus` receiver during service discovery.
+to deploy your Collector. Make sure to replace `<YOUR_REMOTE_WRITE_ENDPOINT>` in the `prometheusremoterwite` exporter config, and `<YOUR_AWS_REGION>` in the `sigv4auth` extension config, as per your own target environment. Note that a `ClusterRole` and `ClusterRoleBinding` will also be created, which provide necessary permissions for the `prometheus` receiver during service discovery.
 
 <details>
   <summary>

--- a/src/docs/getting-started/adot-eks-add-on/config-intro.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/config-intro.mdx
@@ -22,7 +22,7 @@ For more information about Collector configuration, as well as OTLP and Promethe
 * [Collector CRD configuration](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md)
 * [OTLP Receiver configuration](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)
 * [Prometheus Receiver configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)
-* [AWS Prometheus Remote Write Exporter configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsprometheusremotewriteexporter#readme)
+* [Prometheus Remote Write Exporter configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter#readme)
 * [AWS CloudWatch EMF Exporter configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter#readme)
 * [AWS X-Ray Exporter configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter#readme)
 

--- a/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
+++ b/src/docs/getting-started/advanced-prometheus-remote-write-configurations.mdx
@@ -486,31 +486,37 @@ roleRef:
 
 <SectionSeparator />
 
-## AWS Prometheus Remote Write Exporter Configurations
+## Prometheus Remote Write Exporter Configurations
 
-For the AWS Prometheus Remote Write Exporter to sign your HTTP requests with AWS SigV4 (AWS’ authentication protocol for secure authentication), 
-you will need to provide the aws_auth configurations. If aws_auth is not provided, HTTPs requests will not be signed.
+For the Prometheus Remote Write Exporter to sign your HTTP requests with AWS SigV4 (AWS’ authentication protocol for secure authentication), 
+you will need to provide the `auth` configuration with the `sigv4auth` authenticator. If `auth` is not provided, HTTPs requests will not be signed.
 
 ```yaml lineNumbers=true 
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "user-region"
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "https://aws-managed-prometheus-endpoint/v1/api/remote_write"
-    aws_auth:
-      service: "aps"
-      region: "user-region"
+    auth:
+      authenticator: sigv4auth
 ```
 
-Aside from the auth configurations, the AWS Prometheus Remote Write Exporter is also configurable with retry, sending queue, and timeout 
+Aside from the auth configurations, the Prometheus Remote Write Exporter is also configurable with retry, sending queue, and timeout 
 settings. An example of these configurations is provided below.
 
 ```yaml lineNumbers=true 
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "us-east-1"
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "https://aps-workspaces-gamma.us-east-1.amazonaws.com/workspaces/ws-7cd45747-2381-4a2a-847f-fa61a3694a74/api/v1/remote_write"
     namespace: test
     auth:
-      region: "us-east-1"
-      service: "aps"
+      authenticator: sigv4auth
     retry_on_failure:
       enabled: true
       initial_interval: 5s

--- a/src/docs/getting-started/ecs-configurations/ecs-config-section.mdx
+++ b/src/docs/getting-started/ecs-configurations/ecs-config-section.mdx
@@ -51,6 +51,7 @@ Below is an example of a configuration which utilizes ECS and AMP to output metr
 ```yaml lineNumbers=true 
 extensions:
   health_check:
+  sigv4auth:
 
 receivers:
   otlp:
@@ -86,8 +87,10 @@ processors:
           - container.duration
 
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    auth:
+      authenticator: sigv4auth
     resource_to_telemetry_conversion:
       enabled: true
 
@@ -96,13 +99,13 @@ service:
     metrics/application:
       receivers: [otlp]
       processors: [resourcedetection, batch/metrics]
-      exporters: [awsprometheusremotewrite]
+      exporters: [prometheusremotewrite]
     metrics:
       receivers: [awsecscontainermetrics]
       processors: [filter]
-      exporters: [awsprometheusremotewrite]
+      exporters: [prometheusremotewrite]
 
-  extensions: [health_check]
+  extensions: [health_check, sigv4auth]
 ```
 
 ## Amazon CloudWatch Configuration for Application metrics
@@ -379,6 +382,7 @@ By utilizing this configuration you will be able to see datapoints from both met
 ```yaml lineNumbers=true 
 extensions:
   health_check:
+  sigv4auth:
 
 receivers:
   otlp:
@@ -418,8 +422,10 @@ processors:
 
 exporters:
   awsxray:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    auth:
+      authenticator: sigv4auth
     resource_to_telemetry_conversion:
       enabled: true
 
@@ -432,11 +438,11 @@ service:
     metrics/application:
       receivers: [otlp]
       processors: [resourcedetection, batch/metrics]
-      exporters: [awsprometheusremotewrite]
+      exporters: [prometheusremotewrite]
     metrics:
       receivers: [awsecscontainermetrics]
       processors: [filter]
-      exporters: [awsprometheusremotewrite]
+      exporters: [prometheusremotewrite]
 
-  extensions: [health_check]
+  extensions: [health_check, sigv4auth]
 ```

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -121,9 +121,13 @@ By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-
 
 The layer is not configured by default to export Prometheus metrics to Amazon Managed Service for Prometheus (AMP) (https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html). To enable it: 
 
-1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the awsprometheusremoteexporter enabled. Set up the `endpoint` and `region` of your own AMP workspace. Note that since AMP is in preview, only these [AMP supported regions](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP_quotas.html) can be used. 
+1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the `prometheusremoteexporter` and the `sigv4authextension` enabled. Set up the `endpoint` of your own AMP workspace, and `region` of the `sigv4authextension`. 
 ```
 # collector.yaml
+extensions:
+  sigv4auth:
+    service: "aps" 
+    region: <workspace_region>
 
 receivers:
   otlp:
@@ -133,20 +137,20 @@ receivers:
 exporters:
   logging:
   awsxray:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: <workspace_remote_write_url>
-    aws_auth: 
-        service: "aps" 
-        region: <workspace_region>
+    auth: 
+      authenticator: sigv4auth
 
 service:
+  extensions: [sigv4auth]
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]
 ```
 2. Upload this collector config as the OPENTELEMETRY_CONFIG_FILE environment variable to configure the Lambda Layer to export metrics to your workspace, following these [instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda).
 

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -121,7 +121,7 @@ By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-
 
 The layer is not configured by default to export Prometheus metrics to Amazon Managed Service for Prometheus (AMP) (https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html). To enable it: 
 
-1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the `prometheusremoteexporter` and the `sigv4authextension` enabled. Set up the `endpoint` of your own AMP workspace, and `region` of the `sigv4authextension`. 
+1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the `prometheusremotewriteexporter` and the `sigv4authextension` enabled. Set up the `endpoint` of your own AMP workspace, and `region` of the `sigv4authextension`. 
 ```
 # collector.yaml
 extensions:

--- a/src/docs/getting-started/operator.mdx
+++ b/src/docs/getting-started/operator.mdx
@@ -262,6 +262,11 @@ spec:
   image: public.ecr.aws/aws-observability/aws-otel-collector:latest
   mode: deployment
   config: |
+    extensions:
+      sigv4auth:
+        service: "aps"
+        region: <YOUR-AMP-REGION>
+
     receivers:
       prometheus:
         config:
@@ -288,11 +293,10 @@ spec:
         send_batch_size: 10000
 
     exporters:
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         endpoint: <YOUR-AMP-REMOTE-WRITE-ENDPOINT>
-        aws_auth:
-          service: "aps"
-          region: <YOUR-AMP-REGION>
+        auth:
+          authenticator: sigv4auth
       awsemf:
         region: <YOUR-CLOUDWATCH-REGION>
         log_group_name: "/metrics/my-adot-collector"
@@ -301,11 +305,12 @@ spec:
         loglevel: debug
 
     service:
+      extensions: [sigv4auth]
       pipelines:
         metrics:
           receivers: [prometheus]
           processors: []
-          exporters: [awsprometheusremotewrite,awsemf,logging]
+          exporters: [prometheusremotewrite,awsemf,logging]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/docs/getting-started/prometheus-remote-write-exporter.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter.mdx
@@ -25,7 +25,7 @@ to AWS Managed Service for Prometheus (AMP).
 
 <img src={prometheusPipelineEKSImg} alt="Diagram" style="margin: 30px 0;" />
 
-The ADOT-AMP pipeline includes two OpenTelemetry Collector components specific to Prometheus — the Prometheus Receiver and the AWS Prometheus 
+The ADOT-AMP pipeline includes two OpenTelemetry Collector components specific to Prometheus — the Prometheus Receiver and the Prometheus 
 Remote Write Exporter. 
 
 <SectionSeparator />
@@ -99,26 +99,30 @@ relabel_configs:
 
 <SubSectionSeparator />
 
-### AWS Prometheus Remote Write Exporter
+### Prometheus Remote Write Exporter
 
-The configuration for the AWS Prometheus Remote Write Exporter is a lot simpler than the Prometheus receiver. At this stage in the pipeline, metrics 
+The configuration for the Prometheus Remote Write Exporter is a lot simpler than the Prometheus receiver. At this stage in the pipeline, metrics 
 have already been ingested, and we’re ready to export this data to AMP. The minimum requirement for a successful configuration to communicate with AMP is as follows:
 
 ```yaml lineNumbers=true 
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "user-region"
+
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "https://aws-managed-prometheus-endpoint/v1/api/remote_write"
-    aws_auth:
-      service: "aps"
-      region: "user-region"
+    auth:
+      authenticator: sigv4auth
 ```
 
-This configuration sends an HTTPS request that is signed by AWS SigV4 using the credentials that are set up from the prerequisites section. It is 
-mandatory that customers specify the service to be “aps”
+This configuration sends an HTTPS request that is signed by AWS SigV4 using the credentials that are set up from the prerequisites section. 
+This is enabled by using the `sigv4auth` extension. It is mandatory that customers specify the service to be “aps”.
 
 Regardless of the method of deployment, the ADOT Collector must have access to one of the listed options in the 
-[default AWS credentials chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). The AWS Prometheus Remote Write 
-Exporter depends on the AWS Go SDK and uses it to fetch credentials and authenticate. You must ensure that these credentials have remote writing 
+[default AWS credentials chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). The `sigv4auth` 
+extension depends on the AWS Go SDK and uses it to fetch credentials and authenticate. You must ensure that these credentials have remote writing 
 permissions to AMP (`aps:RemoteWrite`).
 
 <SectionSeparator />
@@ -132,4 +136,3 @@ For more advanced configurations with the ADOT Collector-AMP, please take a look
 
 We would love to hear more common configuration scenarios or improvements to this documentation from you! Please submit an issue 
 on the [aws-otel community](https://github.com/aws-observability/aws-otel-community) to let us know.
-

--- a/src/docs/getting-started/prometheus-remote-write-exporter/eks.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter/eks.mdx
@@ -29,9 +29,9 @@ scraping. There are many possible configurations to discover monitored targets i
  and static hosts (static_config). Note that the Prometheus Receiver will scrape metrics in the Prometheus exposition format. Any applications 
  or endpoints that you want to scrape should be configured with the Prometheus client library.
 
-The AWS Prometheus Remote Write Exporter will use the remote_write endpoint to send the scraped metrics to an AMP instance. The HTTPs requests 
+The Prometheus Remote Write Exporter will use the remote_write endpoint to send the scraped metrics to an AMP instance. The HTTPs requests 
 used to export data will be signed with [AWS SigV4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html), AWS’ 
-authentication protocol for secure authentication.
+authentication protocol for secure authentication. This is done using the `sigv4auth` extension.
 
 <SectionSeparator />
 
@@ -142,17 +142,21 @@ To pull the Kubernetes configuration for ADOT Collector:
 $ curl https://raw.githubusercontent.com/aws-observability/aws-otel-collector/main/examples/eks/prometheus-pipeline/eks-prometheus-daemonset.yaml -o eks-prometheus-daemonset.yaml
 ```
 
-You will have to change the `<YOUR_ENDPOINT>` and `<YOUR_REGION>` to correspond with your own AMP workspace. The changes should be with respect to the AWS Prometheus Remote Write Exporter’s configuration. 
+You will have to change the `<YOUR_ENDPOINT>` and `<YOUR_REGION>` to correspond with your own AMP workspace. The changes should be with respect to the Prometheus Remote Write Exporter’s configuration and the `sigv4auth` extension's configuration. 
 
 For Example:
 
 ```yaml lineNumbers=true 
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "us-west-2"
+
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-d26e36bf-361j-480c-94f0-54bd7370f997/api/v1/remote_write"
-    aws_auth:
-      service: "aps"
-      region: "us-west-2"
+    auth:
+      authenticator: sigv4auth
 ```
 
 

--- a/src/docs/releases.mdx
+++ b/src/docs/releases.mdx
@@ -24,7 +24,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 |---------------------------------|-------------------------------|------------------------------------|------------------------|
 | prometheusreceiver              | attributesprocessor           | `awsxrayexporter`                  | healthcheckextension   |
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
-| `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter` | zpagesextension        |
+| `awsecscontainermetricsreceiver`| batchprocessor                | prometheusremotewriteexporter      | zpagesextension        |
 | `awsxrayreceiver`               | memorylimiter                 | loggingexporter                    | `ecsobserver`          |
 | statsdreceiver                  | `metricsgenerationprocessor`  | otlpexporter                       | `awsproxy`             |
 | zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       | ballastextention       |
@@ -35,6 +35,5 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 |                                 | cumulativetodeltaprocessor    | sapmexporter                       |                        |
 |                                 | deltatorateprocessor          | signalfxexporter                   |                        |
 |                                 |                               | logzioexporter                     |                        |
-|                                 |                               | prometheusremotewriteexporter      |                        |
 
-Note: Highlighted components are AWS developed. Also note that the `awsprometheusremotewriteexporter` will be removed at some point after v0.19.0 of the ADOT Collector. Users who want to send metrics to Amazon Managed Service for Prometheus will need to instead use the [Prometheus Remote Write Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md) along with the [Sigv4 Authenticator Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/sigv4authextension/README.md) to achieve the same result.
+Note: Highlighted components are AWS developed. Also note that the `awsprometheusremotewriteexporter` has been removed in v0.21.0 of the ADOT Collector. Users who want to send metrics to Amazon Managed Service for Prometheus will need to instead use the [Prometheus Remote Write Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md) along with the [Sigv4 Authenticator Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/sigv4authextension/README.md) to achieve the same result.


### PR DESCRIPTION
This PR removes references to the `awsprometheusremotewrite` exporter following the removal of it in v0.21.0 of the ADOT Collector.