### PR TITLE
Update honeycomb section to also show pipeline config

### DIFF
--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -321,25 +321,38 @@ To send trace data, all you need is the API key for your Environment:
 ```yaml lineNumbers=true highlight={7,9}
 # Honeycomb Collector configuration
 exporters:
-  otlp:
+  otlp/traces:
     endpoint: api.honeycomb.io:443
     headers:
       # You can find your Honeycomb API key under Environment settings
       "x-honeycomb-team":"<YOUR_API_KEY>"
+service:
+  extensions: []
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp/traces]
 ```
-
 
 To send metrics data, you also need to specify the dataset for metrics data:
 
 ```yaml lineNumbers=true highlight={7,9}
 # Honeycomb Collector configuration
 exporters:
-  otlp:
+  otlp/metrics:
     endpoint: api.honeycomb.io:443
     headers:
       # You can find your Honeycomb API key under Environment settings
       "x-honeycomb-team":"<YOUR_API_KEY>"
       "x-honeycomb-dataset": "<YOUR_METRICS_DATASET>"
+service:
+  extensions: []
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: []
+      exporters: [otlp/metrics]
 ```
 
 See [Honeycomb's OpenTelemetry Collector](https://docs.honeycomb.io/getting-data-in/otel-collector/) docs to learn about additional configuration options.

--- a/src/docs/components/otlp-exporter.mdx
+++ b/src/docs/components/otlp-exporter.mdx
@@ -350,7 +350,7 @@ service:
   extensions: []
   pipelines:
     metrics:
-      receivers: [hostmetrics]
+      receivers: [otlp]
       processors: []
       exporters: [otlp/metrics]
 ```


### PR DESCRIPTION
We've had some people get confused by the wording in our instructions, since they configured an exporter but didn't add it to the exporter pipeline. This addresses that by just including exporter pipeline stuff in each code sample.