### PR TITLE
Correct the version number in the published layer ARN

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and AMD64 (x86_64) layer ARN in the table below for t
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-amd64-ver-1-16-0:6 | Contains [ADOT Java Auto-Instrumentation Agent v1.17.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.17.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.21.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.21.0)|
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-amd64-ver-1-17-0:6 | Contains [ADOT Java Auto-Instrumentation Agent v1.17.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.17.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.21.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.21.0)|
 
 Find the supported regions and ARM64 layer ARN in the table below for the ARNs to consume.
 


### PR DESCRIPTION
This PR fixes the Typo in published layer ARN which is indicating the incorrect Layer ARN with version number