### PR TITLE
Fix span variable name in PHP "Adding Custom Attributes" code snippet

### DIFF
--- a/src/docs/getting-started/php-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/php-sdk/trace-manual-instr.mdx
@@ -220,7 +220,7 @@ $span = $tracer
         ->spanBuilder('span')
         ->startSpan();
         
-$spanScope = $root->activate();
+$spanScope = $span->activate();
         
 $span->setAttributes(["a" => "1"]);
         


### PR DESCRIPTION
This PR fixes the variable name in the "Adding Custom Attributes" section of the PHP manual instrumentation page. The `$root` variable is used in previous code snippets, but the span in this example is named `$span`, so this update ensures that the correct span is being activated to avoid any confusion. 

