### PR TITLE
Update lambda ARNs for release v0.25.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,12 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry Lambda Layers are now available with ADOT Collector v0.25.0"
+    author: "Bryan Aguilar"
+    date: "11-Jan-2023"
+    body:
+      "ADOT Lambda Layers now distribute ADOT Collector v0.25.0 with new layers supporting AMD64 and ARM64 Lambda functions"
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.24.0"
   - title: "AWS Distro for OpenTelemetry v0.25.0 is now available"
     author: "Paurush Garg"
     date: "10-Jan-2023"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.25.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.25.0.mdx
@@ -1,0 +1,53 @@
+---
+title: "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.25.0 are now available"
+description: January 2022 release announcement for ADOT Lambda layers
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+
+<SectionSeparator />
+
+AWS Distro for OpenTelemetry Lambda Layers now supports AMD64 and ARM64 in the following AWS regions:
+
+| Region                    | AMD64 | ARM64 |
+| ------------------------- | ----- | ----- |
+| Asia Pacific (Mumbai)     | ✓     | ✓     |
+| Asia Pacific (Singapore)  | ✓     | ✓     |
+| Asia Pacific (Sydney)     | ✓     | ✓     |
+| Asia Pacific (Tokyo)      | ✓     | ✓     |
+| Asia pacific (Seoul)      | ✓     | ✓     |
+| Canada (Central)          | ✓     | ✓     |
+| Europe (Frankfurt)        | ✓     | ✓     |
+| Europe (Ireland)          | ✓     | ✓     |
+| Europe (London)           | ✓     | ✓     |
+| Europe (Stockholm)        | ✓     | ✓     |
+| Europe(Paris)             | ✓     | ✓     |
+| South America (Sao Paulo) | ✓     | ✓     |
+| US East (N. Virginia)     | ✓     | ✓     |
+| US East (Ohio)            | ✓     | ✓     |
+| US West (N California)    | ✓     | ✓     |
+| US West (Oregon)          | ✓     | ✓     |
+
+<SectionSeparator />
+
+### Release Highlights
+
+- Python layer [**aws-otel-python-<amd64|arm64>-ver-1-15-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.15.0`
+- Nodejs layer [**aws-otel-nodejs-<amd64|arm64>-ver-1-8-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core `v1.8.0` with AWS Lambda Instrumentation `v0.34.0`
+- Java-Wrapper layer [**aws-otel-java-wrapper-<amd64|arm64>-ver-1-21-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java `v1.21.0`
+- Java-Agent layer [**aws-otel-java-agent-<amd64|arm64>-ver-1-20-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS Distro for OpenTelemetry Java Instrumentation `v1.20.0`
+- Collector layer **aws-otel-collector-<amd64|arm64>-ver-0-68-0** contains ADOT Collector for Lambda `v0.25.1`. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+
+### Download
+
+Learn more about AWS Distro for Open Telemetry Lambda support [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are made upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC).
+
+More blog posts about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) can be found on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).
+
+### Author
+
+[Anthony Mirabella](https://github.com/Aneurysm9) is a Senior SDE on the AWS Open-Source Observability team. He is a maintainer of the OpenTelemetry Go client library and Lambda extensions.

--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -1,21 +1,20 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For .NET'
+title: "AWS Distro for OpenTelemetry Lambda Support For .NET"
 description:
-    The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda)
-     provides extension and tracing APIs you can use to instrument your Lambda function.
-     The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector),
-     which can further export OpenTelemetry spans to back-end servers.
+  The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda)
+  provides extension and tracing APIs you can use to instrument your Lambda function.
+  The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector),
+  which can further export OpenTelemetry spans to back-end servers.
 
-path: '/docs/getting-started/lambda/lambda-dotnet'
+path: "/docs/getting-started/lambda/lambda-dotnet"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import img16 from "assets/img/docs/img16.png"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import img16 from "assets/img/docs/img16.png";
 
-The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda) provides extension and tracing APIs you can use to instrument your Lambda function. The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector), which can further export OpenTelemetry spans to back-end servers. 
+The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda) provides extension and tracing APIs you can use to instrument your Lambda function. The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector), which can further export OpenTelemetry spans to back-end servers.
 
 This chapter will walk you through the steps to manually instrument your Lambda function using the ADOT Lambda .NET SDK, and apply ADOT Lambda layer to enable end-to-end tracing.
-
 
 <SectionSeparator />
 
@@ -43,8 +42,8 @@ TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
 ```
 
 3. Create a wrapper function with the same signature as the original Lambda function.
-Call `AWSLambdaWrapper.Trace()` API and pass `TracerProvider`, the original Lambda function, and its inputs as parameters. 
-**Set the wrapper function as the Lambda handler input.** See [sample app](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs) for more code instrumentation details.
+   Call `AWSLambdaWrapper.Trace()` API and pass `TracerProvider`, the original Lambda function, and its inputs as parameters.
+   **Set the wrapper function as the Lambda handler input.** See [sample app](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs) for more code instrumentation details.
 
 ```csharp
 // new Lambda function handler passed in
@@ -60,21 +59,22 @@ public string OriginalFunctionHandler(JObject input, ILambdaContext context)
 ### Lambda Layer
 
 This layer includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
-  which runs as a Lambda extension.
+which runs as a Lambda extension.
 
 Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published.
- Make sure to use the layer in the same region as your Lambda functions.
+Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-66-0:1 | Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0)|
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                                     | Contents                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-68-0:1 | Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable Tracing
+
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.
 
-1. Open the Lambda function you intend to trace in the AWS console. 
+1. Open the Lambda function you intend to trace in the AWS console.
 2. In the **Layers** section, choose **Add a layer**.
 3. Under **Specify an ARN**, paste the layer ARN, and then choose **Add**.
 
@@ -82,10 +82,10 @@ Also, remember to turn on [active tracing](https://docs.aws.amazon.com/lambda/la
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray.
- Make sure your Lambda role has the required AWS X-Ray permissions.
+- By default, the layer is configured to export traces to AWS X-Ray.
+  Make sure your Lambda role has the required AWS X-Ray permissions.
   See more on [AWS X-Ray permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) for AWS Lambda.
-* To disable tracing, you’ll need to remove ADOT Lambda layer from your Lambda function and disable active tracing as described above.
+- To disable tracing, you’ll need to remove ADOT Lambda layer from your Lambda function and disable active tracing as described above.
 
 <SectionSeparator />
 
@@ -94,9 +94,8 @@ Tips:
 The ADOT layer contains the ADOT Collector. The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
- which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
-
+which exports telemetry data to AWS X-Ray. To customize the Collector config,
+see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
 
 <SectionSeparator />
 

--- a/src/docs/getting-started/lambda/lambda-go.mdx
+++ b/src/docs/getting-started/lambda/lambda-go.mdx
@@ -1,21 +1,20 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Go'
+title: "AWS Distro for OpenTelemetry Lambda Support For Go"
 description:
-    The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for Go](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/aws/aws-lambda-go/otellambda)
-     provides extension and tracing APIs you can use to instrument your Lambda function.
-     The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector),
-     which can further export OpenTelemetry spans to back-end servers.
+  The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for Go](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/aws/aws-lambda-go/otellambda)
+  provides extension and tracing APIs you can use to instrument your Lambda function.
+  The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector),
+  which can further export OpenTelemetry spans to back-end servers.
 
-path: '/docs/getting-started/lambda/lambda-go'
+path: "/docs/getting-started/lambda/lambda-go"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import img16 from "assets/img/docs/img16.png"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import img16 from "assets/img/docs/img16.png";
 
 The [AWS Distro for OpenTelemetry Lambda (ADOT Lambda) SDK for Go](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/aws/aws-lambda-go/otellambda) provides extension and tracing APIs you can use to instrument your Lambda function. The ADOT Lambda layer provides a reduced version of the [AWS Distro for OpenTelemetry Collector](https://github.com/aws-observability/aws-otel-collector), which can further export OpenTelemetry spans to back-end servers.
 
 This chapter will walk you through the steps to manually instrument your Lambda function using the ADOT Lambda Go SDK, and apply ADOT Lambda layer to enable end-to-end tracing.
-
 
 <SectionSeparator />
 
@@ -24,13 +23,14 @@ This chapter will walk you through the steps to manually instrument your Lambda 
 The ADOT Lambda Go SDK supports the `provided.al2` Lambda runtime.
 
 ### Converting from `go1.x` runtime to `provided.al2`
+
 Change Lambda Runtime from go1.x → provided.al2 via AWS Console or AWS CLI command:
+
 ```shell
 aws lambda update-function-configuration --function-name <FUNCTION> --runtime provided.al2
 ```
 
 Re-upload source zip with function executable renamed to `bootstrap`
-
 
 ## Instrumentation
 
@@ -48,7 +48,9 @@ import (
     "go.opentelemetry.io/otel"
 )
 ```
+
 2. Add below code which is using configured tracer provider and shutting down the tracer provider in `main()` function outside of lambda handler. Customer can configure their own custom tracer provider as well and pass it on to the Go Lambda instrumentation wrapper.
+
 ```go
    	ctx := context.Background()
 
@@ -69,6 +71,7 @@ import (
 ```
 
 3. Wrap handler in call to `lambda.Start()` or `lambda.StartHandler()` in `main()` function using the recommended X-Ray configuration options.
+
 ```go
 lambda.Start(otellambda.InstrumentHandler(lambda_handler(ctx), xrayconfig.WithRecommendedOptions(tp)... ))
 ```
@@ -78,21 +81,22 @@ lambda.Start(otellambda.InstrumentHandler(lambda_handler(ctx), xrayconfig.WithRe
 ### Lambda Layer
 
 This layer includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
-  which runs as a Lambda extension.
+which runs as a Lambda extension.
 
 Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published.
- Make sure to use the layer in the same region as your Lambda functions.
+Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-66-0:1 | Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0)|
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                                     | Contents                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-68-0:1 | Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable Tracing
+
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.
 
-1. Open the Lambda function you intend to trace in the in AWS console. 
+1. Open the Lambda function you intend to trace in the in AWS console.
 2. In the **Layers** section, choose **Add a layer**.
 3. Under **Specify an ARN**, paste the layer ARN, and then choose **Add**.
 
@@ -100,10 +104,10 @@ Also, remember to turn on [active tracing](https://docs.aws.amazon.com/lambda/la
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray.
- Make sure your Lambda role has the required AWS X-Ray permissions.
+- By default, the layer is configured to export traces to AWS X-Ray.
+  Make sure your Lambda role has the required AWS X-Ray permissions.
   See more on [AWS X-Ray permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) for AWS Lambda.
-* To disable tracing, you’ll need to remove ADOT Lambda layer from your Lambda function and disable active tracing as described above.
+- To disable tracing, you’ll need to remove ADOT Lambda layer from your Lambda function and disable active tracing as described above.
 
 <SectionSeparator />
 
@@ -112,9 +116,8 @@ Tips:
 The ADOT layer contains the ADOT Collector. The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
- which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
-
+which exports telemetry data to AWS X-Ray. To customize the Collector config,
+see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
 
 <SectionSeparator />
 

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Java (Auto-instrumentation Agent)'
+title: "AWS Distro for OpenTelemetry Lambda Support For Java (Auto-instrumentation Agent)"
 description:
-    The AWS managed Lambda layer for ADOT Java Auto-instrumentation Agent provides a plug-and-play user experience by automatically instrumenting a AWS Lambda function, by packaging either the ADOT Java Agent (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr) or OpenTelemetry Java SDK (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-    With the ADOT Lambda Layer for Java Auto-instrumentation Agent, all supported libraries are automatically instrumented, with no additional configurations needed.
-path: '/docs/getting-started/lambda/lambda-java-auto-instr'
+  The AWS managed Lambda layer for ADOT Java Auto-instrumentation Agent provides a plug-and-play user experience by automatically instrumenting a AWS Lambda function, by packaging either the ADOT Java Agent (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr) or OpenTelemetry Java SDK (https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+  With the ADOT Lambda Layer for Java Auto-instrumentation Agent, all supported libraries are automatically instrumented, with no additional configurations needed.
+path: "/docs/getting-started/lambda/lambda-java-auto-instr"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx";
 
 The AWS managed Lambda layer for ADOT Java Auto-instumentation Agent provides a plug-and-play user experience by automatically instrumenting a Lambda function, by packaging the [ADOT Java Agent](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr) together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
 
@@ -27,25 +27,25 @@ Note: Lambda layers are a regionalized resource, meaning that they can only be u
 
 Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-20-1:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.20.1](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.20.1) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0)|
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                                      | Contents                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-21-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.21.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.21.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable auto-instrumentation for your Lambda function
 
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
-1. Open the Lambda function you intend to instrument in the AWS console. 
-2. In the *Layers in Designer* section, choose *Add a layer*.
-3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+1. Open the Lambda function you intend to instrument in the AWS console.
+2. In the _Layers in Designer_ section, choose _Add a layer_.
+3. Under _specify an ARN_, paste the layer ARN, and then choose _Add_.
 4. Add the environment variable AWS_LAMBDA_EXEC_WRAPPER and set it to one of the following options:
-    1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
+   1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray. Make sure your Lambda role has the required AWS X-Ray permissions.
-For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+- By default, the layer is configured to export traces to AWS X-Ray. Make sure your Lambda role has the required AWS X-Ray permissions.
+  For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Metric Instrumentation in your Lambda Function
 
@@ -54,13 +54,16 @@ For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentat
 Unlike traces, Metric auto instrumentation has not been supported in OpenTelemetry yet. You would have to manually instrument your code in your Lambda application in order to generate application metrics. We will be using the [OpenTelemetry Java Metrics API](https://github.com/open-telemetry/opentelemetry-java/tree/main/api/metrics/src/main/java/io/opentelemetry/api/metrics) to define our metrics. You can define your metric types in a MetricGenerator.java file.
 
 1. Import the OpenTelemetry Java Metrics API into your dependency file
+
 ```
 dependencies {
   implementation platform("io.opentelemetry:opentelemetry-bom:1.6.0")
   implementation('io.opentelemetry:opentelemetry-api')
 }
 ```
+
 2. Create Metric instruments by using the OpenTelemetry Java Metrics API
+
 ```
 // get meter
 Meter meter = GlobalMeterProvider.getMeter("aws-otel", "1.0");
@@ -71,14 +74,14 @@ LongUpDownCounter apiBytesSentCounter = meter
         .setDescription("API request payload sent in bytes")
         .setUnit("one")
         .build();
-        
+
 // creating a Histogram metric to record API latency in timeseries
 LongValueRecorder apiLatencyRecorder = meter
         .longValueRecorderBuilder("latency")
         .setDescription("API latency time")
         .setUnit("ms")
         .build();
-        
+
 // creating a Gauge metric to record memory usage at every collection interval
 LongValueObserver memoryObserver = meter
         .gaugeBuilder("jvm.memory.total")
@@ -88,15 +91,17 @@ LongValueObserver memoryObserver = meter
 ```
 
 3. Record Metric measurements
+
 ```
 // record your metrics
 apiBytesSentCounter.add(100, Labels.of("apiName", apiName));
 apiLatencyRecorder.record(248, Labels.of("apiName", apiName));
 memoryObserver.observer(Runtime.getRuntime().totalMemory(), Attributes.empty());
 ```
+
 4. The Lambda layer will take care of exporting the metrics to the Collector and then to AMP.
 
-*Please note that the [OpenTelemetry Java Metrics API](https://github.com/open-telemetry/opentelemetry-java) is currently in alpha, there may be future breaking changes to the API.* 
+_Please note that the [OpenTelemetry Java Metrics API](https://github.com/open-telemetry/opentelemetry-java) is currently in alpha, there may be future breaking changes to the API._
 
 ### Remove OpenTelemetry from your Lambda function
 
@@ -113,14 +118,15 @@ By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-
 
 ## Exporting Metrics to AMP
 
-The layer is not configured by default to export Prometheus metrics to Amazon Managed Service for Prometheus (AMP) (https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html). To enable it: 
+The layer is not configured by default to export Prometheus metrics to Amazon Managed Service for Prometheus (AMP) (https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html). To enable it:
 
-1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the `prometheusremotewriteexporter` and the `sigv4authextension` enabled. Set up the `endpoint` of your own AMP workspace, and `region` of the `sigv4authextension`. 
+1. Upload a custom collector configuration file `collector.yaml` with your Lambda application, like the example shown below, with the `prometheusremotewriteexporter` and the `sigv4authextension` enabled. Set up the `endpoint` of your own AMP workspace, and `region` of the `sigv4authextension`.
+
 ```
 # collector.yaml
 extensions:
   sigv4auth:
-    service: "aps" 
+    service: "aps"
     region: <workspace_region>
 
 receivers:
@@ -133,7 +139,7 @@ exporters:
   awsxray:
   prometheusremotewrite:
     endpoint: <workspace_remote_write_url>
-    auth: 
+    auth:
       authenticator: sigv4auth
 
 service:
@@ -146,13 +152,14 @@ service:
       receivers: [otlp]
       exporters: [logging, prometheusremotewrite]
 ```
+
 2. Upload this collector config as the OPENTELEMETRY_CONFIG_FILE environment variable to configure the Lambda Layer to export metrics to your workspace, following these [instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda).
 
 Note: If enabling metrics, make sure your Lambda role has the required AWS Prometheus permissions. For more on permissions and policies required on AMP for AWS Lambda, see the [AWS Managed Service for Prometheus documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-and-IAM.html#AMP-IAM-policies-built-in).
 
 ## AMP and AWS Lambda Service Quotas when using the Lambda Layer for Metrics
 
-To learn more about the limits for the number of metrics that can be sent through this Lambda Layer to Amazon Service for Prometheus, refer to the [AMP service quotas](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP_quotas.html). The layer has been tested to output up to the posted service Quotas of AMP without requesting for an increase.  This layer has been tested with the maximum concurrency levels of [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html), of 1000 concurrent invocations, and is able to receive all metrics in AMP. Any higher levels of concurrency or of the posted service quota is not guaranteed. 
+To learn more about the limits for the number of metrics that can be sent through this Lambda Layer to Amazon Service for Prometheus, refer to the [AMP service quotas](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP_quotas.html). The layer has been tested to output up to the posted service Quotas of AMP without requesting for an increase. This layer has been tested with the maximum concurrency levels of [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html), of 1000 concurrent invocations, and is able to receive all metrics in AMP. Any higher levels of concurrency or of the posted service quota is not guaranteed.
 
 <SectionSeparator />
 
@@ -164,6 +171,6 @@ For additional instrumentation, see the [OpenTelemetry Java documentation](https
 
 ## Appendix
 
-Keep up to date with the development of the ADOT Lambda layers [here](https://github.com/aws-observability/aws-otel-lambda). If you’re interested in building your own custom Lambda Layers, visit the upstream [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda) repository. 
+Keep up to date with the development of the ADOT Lambda layers [here](https://github.com/aws-observability/aws-otel-lambda). If you’re interested in building your own custom Lambda Layers, visit the upstream [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda) repository.
 
 To participate in the discussions to address compatibility gaps between OpenTelemetry and Prometheus, you can also join the [OpenTelemetry Prometheus workgroup](https://github.com/open-telemetry/wg-prometheus).

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -1,23 +1,21 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Java'
-description:
-    The AWS managed Lambda layer for ADOT Java provides
-     a plug-and-play user experience by wrapping an AWS Lambda function,
-     and by packaging the [OpenTelemetry Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)
-     together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
-     Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-     With the ADOT Lambda Layer for Java, the wrapper has built-in support for instrumenting the AWS SDK automatically.
-     For additional instrumenting functionality, see the documentation on [auto-instrumentation for traces](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/README.md).
+title: "AWS Distro for OpenTelemetry Lambda Support For Java"
+description: The AWS managed Lambda layer for ADOT Java provides
+  a plug-and-play user experience by wrapping an AWS Lambda function,
+  and by packaging the [OpenTelemetry Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr)
+  together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+  Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+  With the ADOT Lambda Layer for Java, the wrapper has built-in support for instrumenting the AWS SDK automatically.
+  For additional instrumenting functionality, see the documentation on [auto-instrumentation for traces](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/README.md).
 
-path: '/docs/getting-started/lambda/lambda-java'
+path: "/docs/getting-started/lambda/lambda-java"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
 
 The AWS managed Lambda layer for ADOT Java provides a plug-and-play user experience by wrapping an AWS Lambda function, and by packaging the [OpenTelemetry Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr) together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
 
 With the ADOT Lambda Layer for Java, the wrapper has built-in support for instrumenting the AWS SDK automatically. For additional instrumenting functionality, see the documentation on [auto-instrumentation for traces](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr).
-
 
 <SectionSeparator />
 
@@ -29,45 +27,42 @@ see the [OpenTelemetry Java documentation](https://github.com/open-telemetry/ope
 ### Add the ARN of the Lambda Layer
 
 In this section, we consume the Lambda layer for use with Java Lambda Functions.
- This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
-  which runs as a Lambda extension.
+This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
+which runs as a Lambda extension.
 
 Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published.
- Make sure to use the layer in the same region as your Lambda functions.
+Make sure to use the layer in the same region as your Lambda functions.
 
-Find the supported regions and amd64(x86_64) layer ARN in the table below for the ARNs to consume.
+Find the supported regions and amd64(x86_64) layer ARN in the table
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-3<br/>us-east-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-amd64-ver-1-20-1:3 | Contains [OpenTelemetry for Java v1.20.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.20.1) with [Java Instrumentation v1.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.20.1) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0) |
-| ap-south-1<br/>ap-southeast-1<br/>eu-west-2<br/>sa-east-1<br/>us-east-1 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-amd64-ver-1-20-1:2 | Contains [OpenTelemetry for Java v1.20.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.20.1) with [Java Instrumentation v1.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.20.1) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0) |
-| us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-amd64-ver-1-20-1:1 | Contains [OpenTelemetry for Java v1.20.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.20.1) with [Java Instrumentation v1.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.20.1) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0) |
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                              | Contents                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-3<br/>us-east-2<br/>ap-south-1<br/>ap-southeast-1<br/>eu-west-2<br/>sa-east-1<br/>us-east-1<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-amd64-ver-1-21-0:1 | Contains [OpenTelemetry for Java v1.21.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.21.0) with [Java Instrumentation v1.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.21.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 Find the supported regions and arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| | ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-arm64-ver-1-20-1:1 | Contains [OpenTelemetry for Java v1.20.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.20.1) with [Java Instrumentation v1.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.20.1) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0) |
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                              | Contents                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-arm64-ver-1-21-0:1 | Contains [OpenTelemetry for Java v1.21.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.21.0) with [Java Instrumentation v1.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.21.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable auto-instrumentation for your Lambda function
+
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
 1. Open the Lambda function you intend to instrument in the AWS console.
-2. In the *Layers in Designer* section, choose *Add a layer*.
-3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+2. In the _Layers in Designer_ section, choose _Add a layer_.
+3. Under _specify an ARN_, paste the layer ARN, and then choose _Add_.
 4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to one of the following options:
-    1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
-    2. `/opt/otel-proxy-handler` - for wrapping regular handlers (implementing RequestHandler) proxied through API Gateway, enabling HTTP context propagation
-    3. `/opt/otel-stream-handler` - for wrapping streaming handlers (implementing RequestStreamHandler), enabling HTTP context propagation for HTTP requests
-    4. `/opt/otel-sqs-handler` - for wrapping SQS-triggered function handlers (implementing RequestHandler)
+   1. `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
+   2. `/opt/otel-proxy-handler` - for wrapping regular handlers (implementing RequestHandler) proxied through API Gateway, enabling HTTP context propagation
+   3. `/opt/otel-stream-handler` - for wrapping streaming handlers (implementing RequestStreamHandler), enabling HTTP context propagation for HTTP requests
+   4. `/opt/otel-sqs-handler` - for wrapping SQS-triggered function handlers (implementing RequestHandler)
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
-
-
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray.
- Make sure your Lambda role has the required AWS X-Ray permissions.
+- By default, the layer is configured to export traces to AWS X-Ray.
+  Make sure your Lambda role has the required AWS X-Ray permissions.
   See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Enable additional instrumentation
@@ -77,7 +72,7 @@ is included and loaded automatically if you use the AWS SDK.
 
 However, for any other library, you will need to include the corresponding library instrumentation
 from the [OpenTelemetry instrumentation repository](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
- and modify your code to initialize it in your function. See the README.MD file for each library for additional information.
+and modify your code to initialize it in your function. See the README.MD file for each library for additional information.
 
 You can see an example with OKHttp in the [OpenTelemetry Lambda sample application](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/java#sample-applications).
 
@@ -85,7 +80,6 @@ You can see an example with OKHttp in the [OpenTelemetry Lambda sample applicati
 
 To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
 remove the environment `variable AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
-
 
 <SectionSeparator />
 
@@ -95,9 +89,8 @@ The AWS Lambda layer for ADOT Java combines both the ADOT Java SDK and the ADOT 
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
- which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
-
+which exports telemetry data to AWS X-Ray. To customize the Collector config,
+see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
 
 <SectionSeparator />
 

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -1,15 +1,14 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For JavaScript'
-description:
-    The AWS managed Lambda layer for ADOT JavaScript provides
-    a plug and play user experience by automatically instrumenting a Lambda function,
-    by packaging [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
-    together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
-    Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-path: '/docs/getting-started/lambda/lambda-js'
+title: "AWS Distro for OpenTelemetry Lambda Support For JavaScript"
+description: The AWS managed Lambda layer for ADOT JavaScript provides
+  a plug and play user experience by automatically instrumenting a Lambda function,
+  by packaging [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
+  together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+  Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+path: "/docs/getting-started/lambda/lambda-js"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
 
 The AWS managed Lambda layer for ADOT JavaScript provides a plug and play user experience by automatically instrumenting a Lambda function, by packaging [OpenTelemetry JavaScript](https://aws-otel.github.io/docs/getting-started/javascript-sdk) together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
 
@@ -27,26 +26,28 @@ Note: Lambda layers are a regionalized resource, meaning that they can only be u
 
 Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-8-0:1 |Contains [OpenTelemetry for JavaScript v1.8.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/stable%2Fv1.8.0) with [Lambda instrumentation v0.34.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.34.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0)|
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                                 | Contents                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-8-0:2 | Contains [OpenTelemetry for JavaScript v1.8.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/stable%2Fv1.8.0) with [Lambda instrumentation v0.34.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.34.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable auto-instrumentation for your Lambda function
+
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
 1. Open the Lambda function you intend to instrument in the AWS console.
-2. In the *Layers in Designer* section, choose *Add a layer*.
-3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+2. In the _Layers in Designer_ section, choose _Add a layer_.
+3. Under _specify an ARN_, paste the layer ARN, and then choose _Add_.
 4. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to `/opt/otel-handler`.
 5. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray.
- Make sure your Lambda role has the required AWS X-Ray permissions.
+- By default, the layer is configured to export traces to AWS X-Ray.
+  Make sure your Lambda role has the required AWS X-Ray permissions.
   For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Remove OpenTelemetry from your Lambda function
+
 To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
 remove the environment variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
 
@@ -58,9 +59,8 @@ The ADOT Node.js layer combines both OpenTelemetry JavaScript and the ADOT Colle
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
- which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
-
+which exports telemetry data to AWS X-Ray. To customize the Collector config,
+see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
 
 <SectionSeparator />
 

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -1,16 +1,15 @@
 ---
-title: 'AWS Distro for OpenTelemetry Lambda Support For Python'
-description:
-    The AWS managed Lambda layer for ADOT Python provides
-    a plug and play user experience by automatically instrumenting a Lambda function,
-    by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python)
-    together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
-    Users can enable and disable OpenTelemetry for their Lambda function without changing code.
-path: '/docs/getting-started/lambda/lambda-python'
+title: "AWS Distro for OpenTelemetry Lambda Support For Python"
+description: The AWS managed Lambda layer for ADOT Python provides
+  a plug and play user experience by automatically instrumenting a Lambda function,
+  by packaging [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python)
+  together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray.
+  Users can enable and disable OpenTelemetry for their Lambda function without changing code.
+path: "/docs/getting-started/lambda/lambda-python"
 ---
 
-import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx"
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import SubSectionSeparator from "components/MdxSubSectionSeparator/subsectionSeparator.jsx";
 
 The AWS managed Lambda layer for ADOT Python provides a plug and play user experience by automatically instrumenting a Lambda function, by packaging [OpenTelemetry Python](https://aws-otel.github.io/docs/getting-started/python-sdk) together with an out-of-the-box configuration for AWS Lambda and AWS X-Ray. Users can enable and disable OpenTelemetry for their Lambda function without changing code.
 
@@ -23,34 +22,36 @@ The Lambda layer supports Python 3.8 and Python 3.9 Lambda runtimes. For more in
 ### Add the ARN of the Lambda Layer
 
 In this section, we consume the Lambda layer for use with Python Lambda Functions.
- This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
-  which runs as a Lambda extension.
+This includes a reduced version of the [AWS Distro for OpenTelemetry Collector (ADOT Collector)](https://github.com/aws-observability/aws-otel-collector),
+which runs as a Lambda extension.
 
 Note: Lambda layers are a regionalized resource, meaning that they can only be used in the Region in which they are published. Make sure to use the layer in the same region as your Lambda functions.
 
 Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below for the ARNs to consume.
 
-|Supported   Regions  |Lambda layer ARN format  | Contents |
-|---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-15-0:1 | Contains [OpenTelemetry Python v1.15.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.15.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.24.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.24.0)|
+| Supported Regions                                                                                                                                                                                                                                       | Lambda layer ARN format                                                                  | Contents                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-15-0:2 | Contains [OpenTelemetry Python v1.15.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.15.0) <br/><br/> Contains the [ADOT Collector for Lambda v0.25.1](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.25.1) |
 
 ### Enable auto-instrumentation for your Lambda function
+
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.
 
 1. Open the Lambda function you intend to instrument in the AWS console.
-2. In the *Layers in Designer* section, choose *Add a layer*.
-3. Under *specify an ARN*, paste the layer ARN, and then choose *Add*.
+2. In the _Layers in Designer_ section, choose _Add a layer_.
+3. Under _specify an ARN_, paste the layer ARN, and then choose _Add_.
 4. [Enable active tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) for your AWS Lambda function.
 5. Add the environment variable `AWS_LAMBDA_EXEC_WRAPPER` and set it to `/opt/otel-instrument`.
 
 Tips:
 
-* By default, the layer is configured to export traces to AWS X-Ray.
- When you enable active tracing, Lambda will try to automatically add the necessary X-Ray permission to your Lambda role if they are missing.
- In the case it is unsuccessful, make sure your Lambda role has the required AWS X-Ray permissions.
- For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
+- By default, the layer is configured to export traces to AWS X-Ray.
+  When you enable active tracing, Lambda will try to automatically add the necessary X-Ray permission to your Lambda role if they are missing.
+  In the case it is unsuccessful, make sure your Lambda role has the required AWS X-Ray permissions.
+  For more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
 ### Remove OpenTelemetry from your Lambda function
+
 To disable OpenTelemetry for your Lambda function, remove the Lambda layer,
 remove the environment variable `AWS_LAMBDA_EXEC_WRAPPER`, and disable active tracing, as explained in the section above.
 
@@ -62,9 +63,8 @@ The ADOT Python layer combines both OpenTelemetry Python and the ADOT Collector.
 The configuration of the ADOT Collector follows the OpenTelemetry standard.
 
 By default, the ADOT Lambda layer uses the [config.yaml](https://github.com/aws-observability/aws-otel-lambda/blob/main/adot/collector/config.yaml),
- which exports telemetry data to AWS X-Ray. To customize the Collector config,
- see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
-
+which exports telemetry data to AWS X-Ray. To customize the Collector config,
+see the [main Lambda section for custom configuration instructions](/docs/getting-started/lambda#custom-configuration-for-the-adot-collector-on-lambda)
 
 <SectionSeparator />
 


### PR DESCRIPTION
Update lambda docs with new ARNs. There are some autoformatting changes made in this PR also. I have verified that each page displays correctly locally. 