### PR TITLE
Update cloudwatch IAM policies to include retention

### DIFF
--- a/src/docs/getting-started/container-insights/ecs-prometheus.mdx
+++ b/src/docs/getting-started/container-insights/ecs-prometheus.mdx
@@ -292,6 +292,7 @@ Policy document merged from <Link to="/docs/setup/ecs/create-iam-policy">ECS set
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
                 "xray:PutTraceSegments",
                 "xray:PutTelemetryRecords",
                 "xray:GetSamplingRules",

--- a/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
+++ b/src/docs/getting-started/prometheus-remote-write-exporter/ecs.mdx
@@ -58,6 +58,7 @@ Please follow the steps outlined in this guide: [Creating an IAM policy](https:/
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
                 "ssm:GetParameters"
             ],
             "Resource": "*"

--- a/src/docs/setup/ecs/create-iam-policy.mdx
+++ b/src/docs/setup/ecs/create-iam-policy.mdx
@@ -48,6 +48,7 @@ Click the `JSON` tab on top of the page. Copy and paste the following policy tex
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
                 "xray:PutTraceSegments",
                 "xray:PutTelemetryRecords",
                 "xray:GetSamplingRules",

--- a/src/docs/setup/permissions.mdx
+++ b/src/docs/setup/permissions.mdx
@@ -30,6 +30,7 @@ AWS X-Ray for sending traces.
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
                 "xray:PutTraceSegments",
                 "xray:PutTelemetryRecords",
                 "xray:GetSamplingRules",


### PR DESCRIPTION
EMF Exporter can now set retention policy on cloudwatch log groups. This requires a specific policy in least privilege IAM roles. See issue here https://github.com/aws-observability/aws-otel-collector/issues/1768