### PR TITLE
Resource/Page not available at provided links

### DIFF
--- a/src/docs/getting-started/collector.mdx
+++ b/src/docs/getting-started/collector.mdx
@@ -12,8 +12,8 @@ To build ADOT Collector locally, you will need to have Golang installed. You can
 ### Try out ADOT Collector 
 ADOT Collector supports all AWS computing platforms and docker/kubernetes. Here are some examples on how to run ADOT Collector to send telemetry data:
 * [Run it with Docker](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/docker-demo.md)
-* [Run it with ECS](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/ecs-demo.md)
-* [Run it with EKS](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/eks-demo.md)
+* [Run it with ECS](/docs/setup/ecs)
+* [Run it with EKS](/docs/setup/eks)
 * [Run it on AWS Linux EC2](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/linux-rpm-demo.md)
 * [Run it on AWS Windows EC2](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/windows-other-demo.md)
 * [Run it on AWS Debian EC2](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/debian-deb-demo.md)


### PR DESCRIPTION
https://aws-otel.github.io/docs/getting-started/collector 

- [Run it with ECS](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/ecs-demo.md)

- [Run it with EKS](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/eks-demo.md)

are showing 404 errors.
This PR should point them to the relevant links.