### PR TITLE
Remove sidecar preference statement

### DIFF
--- a/src/docs/getting-started/collector/sidecar-vs-service.mdx
+++ b/src/docs/getting-started/collector/sidecar-vs-service.mdx
@@ -7,8 +7,7 @@ path: '/docs/getting-started/collector/sidecar-vs-service'
 
 When setting up the ADOT Collector, you will generally decide between two different types of deployment, sidecar or
 service. A sidecar deployment runs a process of the Collector next to each process of each of your applications while a
-service would have a Collector process shared by multiple applications in your system. We generally recommend sidecar
-deployment to support all the functionality of the collector.
+service would have a Collector process shared by multiple applications in your system.
 
 ## Sidecar
 

--- a/src/docs/getting-started/collector/sidecar-vs-service.mdx
+++ b/src/docs/getting-started/collector/sidecar-vs-service.mdx
@@ -45,8 +45,7 @@ scalability and reliability. By deploying the Collector as a service, it will ha
 the others in the system. Applications will communiate with the Collector through a service endpoint.
 
 Because the Collector runs independently from applications, it will not have visiblity into application-specific state,
-for example the Kubernetes pod running the application. For this reason, we generally recommend deploying as a sidecar
-to unlock all the functionality of the collector.
+for example the Kubernetes pod running the application.
 
 When running the Collector as a service, you will need to configure TLS as well to ensure communication from
 applications is secure. Receivers can be configured with TLS certificates, for example,


### PR DESCRIPTION
The collector getting started guide provides a statement that we generally recommend sidecar deployments.  This isn't telling the whole story and things are generally a lot more complicated than that, so let's remove that language.