### PR TITLE
Documentation for ADOT .Net remote sampling

### DIFF
--- a/src/docs/getting-started/dotnet-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/dotnet-sdk/trace-manual-instr.mdx
@@ -121,6 +121,50 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+### Using X-Ray Remote Sampling
+
+The `OpenTelemetry.Sampler.AWS` nuget package provides a `Sampler` implementation for use with [X-Ray remote sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html).
+
+```shell
+dotnet add package OpenTelemetry.Sampler.AWS
+```
+
+When initializing the `TracerProvider`, register the `AWSXRayRemoteSampler`. Moreover, you can configure the following attributes for the sampler.
+
+| **Attribute**     | **Type** | **Description**                                                      | **Default**             |
+|-------------------|----------|----------------------------------------------------------------------|-------------------------|
+| `pollingInterval` | TimeSpan | Duration between polling the GetSamplingRules API                    | 5 minutes               |
+| `endpoint`        | string   | Endpoint used to communicate with the `awsproxy` collector extension | `http://localhost:2000` |
+
+
+```csharp linenumbers=true
+using OpenTelemetry;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Resources;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using OpenTelemetry.Sampler.AWS;
+using OpenTelemetry.Trace;
+
+var serviceName = "MyServiceName";
+
+var resourceBuilder = ResourceBuilder
+    .CreateDefault()
+    .AddService(serviceName: serviceName)
+    .AddDetector(new AWSEC2ResourceDetector()); // optionally add any detector for your platform
+
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource(serviceName)
+    .SetResourceBuilder(resourceBuilder)
+    .AddConsoleExporter() // optionally add the exporter for the spans
+    .SetSampler(AWSXRayRemoteSampler.Builder(resourceBuilder.Build()) // you must provide a resource
+        .SetPollingInterval(TimeSpan.FromMinutes(10))
+        .SetEndpoint("http://localhost:2000")
+        .Build())
+    .Build();
+```
+
+Please note that you will also need to [configure the OpenTelemetry collector](/docs/getting-started/remote-sampling) to allow the application to fetch sampling configuration for AWS X-Ray service.
+If the AWS X-Ray remote sampler is unable to fetch the sampling configurations due to network or configuration issue, the sampler will sample the requests at a default rate of 1 request per second and 5% of additional requests during that second.
+
 <SectionSeparator />
 
 ## Custom Instrumentation

--- a/src/docs/getting-started/remote-sampling.mdx
+++ b/src/docs/getting-started/remote-sampling.mdx
@@ -14,6 +14,7 @@ Note that in order to use X-Ray remote sampling, your application's tracer must 
 * [ADOT Java agent](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr#using-x-ray-remote-sampling)
 * [ADOT Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr#using-x-ray-remote-sampling)
 * [ADOT Go SDK](https://aws-otel.github.io/docs/getting-started/go-sdk/trace-manual-instr#using-x-ray-remote-sampling)
+* [ADOT .Net SDK](https://aws-otel.github.io/docs/getting-started/dotnet-sdk/trace-manual-instr#using-x-ray-remote-sampling)
 
 Enable the extension by adding this snippet to your collector configuration.
 


### PR DESCRIPTION
The work for adding the X-Ray Remote Sampling to OTel .Net is underway. 
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Sampler.AWS

I'm creating this PR preemptively for the doc update when the sampler is released.