### PR TITLE
docs: fix link to lambda issue for java

### DIFF
--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -60,7 +60,7 @@ Tips:
  Make sure your Lambda role has the required AWS X-Ray permissions.
   See more on AWS X-Ray permissions for AWS Lambda, see the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions).
 
-Note: Inside the Java-Wrapper layer only the 1 kind of APIGW (APIGatewayProxyRequestEvent) event object is currently supported. The issue is currently being tracked [here](open-telemetry/opentelemetry-lambda#270)
+Note: Inside the Java-Wrapper layer only the 1 kind of APIGW (APIGatewayProxyRequestEvent) event object is currently supported. The issue is currently being tracked [here](https://github.com/open-telemetry/opentelemetry-lambda/issues/270)
 
 ### Enable additional instrumentation
 


### PR DESCRIPTION
Updates the link to the open issue for lambda for end users to find; current link is invalid and ends up at a 404 page.