### PR TITLE
Update Lambda ARNs and blog posts in website

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,7 +6,7 @@ description:
 path: /blog
 
 blogs:
-- title: "AWS Distro for OpenTelemetry Lambda Layers are now available with ADOT Collector v0.29.0"
+  - title: "AWS Distro for OpenTelemetry Lambda Layers are now available with ADOT Collector v0.29.0"
     author: "Huy Vo"
     date: "7-June-2023"
     body:

--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,13 @@ description:
 path: /blog
 
 blogs:
+- title: "AWS Distro for OpenTelemetry Lambda Layers are now available with ADOT Collector v0.29.0"
+    author: "Huy Vo"
+    date: "7-June-2023"
+    body:
+      "ADOT Lambda Layers now distribute ADOT Collector v0.29.0 with new layers supporting AMD64 and ARM64 Lambda functions"
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0"
+
   - title: "AWS Distro for OpenTelemetry EKS Add-on v0.76.1 is now available"
     author: "Bryan Aguilar"
     date: "6-June-2023"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
@@ -53,4 +53,4 @@ More blog posts about
 
 ### Author
 
-[Huy Vo](https://github.com/humivo) is a Software Development Engineer on the AWS OpenSource Observability team.
+[Huy Vo](https://github.com/humivo) is a Software Development Engineer I on the AWS OpenSource Observability team.

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
@@ -1,0 +1,56 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.29.0 are now available'
+description:
+    May 2023 release announcement for ADOT Lambda layers
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+AWS Distro for OpenTelemetry Lambda Layers now supports AMD64 and ARM64 in the following AWS regions:
+
+|Region                   | AMD64 | ARM64 |
+|-------------------------|-------|-------|
+|Asia Pacific (Mumbai)    |  ✓    |  ✓    |
+|Asia Pacific (Singapore) |  ✓    |  ✓    |
+|Asia Pacific (Sydney)    |  ✓    |  ✓    |
+|Asia Pacific (Tokyo)     |  ✓    |  ✓    |
+|Asia pacific (Seoul)     |  ✓    |  ✓    |
+|Canada (Central)         |  ✓    |  ✓    |
+|Europe (Frankfurt)       |  ✓    |  ✓    |
+|Europe (Ireland)         |  ✓    |  ✓    |
+|Europe (London)          |  ✓    |  ✓    |
+|Europe (Stockholm)       |  ✓    |  ✓    |
+|Europe(Paris)            |  ✓    |  ✓    |
+|South America (Sao Paulo)|  ✓    |  ✓    |
+|US East (N. Virginia)    |  ✓    |  ✓    |
+|US East (Ohio)           |  ✓    |  ✓    |
+|US West (N California)   |  ✓    |  ✓    |
+|US West (Oregon)         |  ✓    |  ✓    |
+
+<SectionSeparator />
+
+### Release Highlights
+
+- Python layer [**aws-otel-python-<amd64|arm64>-ver-1-18-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.18.0`
+- Nodejs layer [**aws-otel-nodejs-<amd64|arm64>-ver-1-13-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core `v1.13.0` with AWS Lambda Instrumentation `v0.35.2`
+- Java-Wrapper layer [**aws-otel-java-wrapper-<amd64|arm64>-ver-1-26-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java `v1.26.0`
+- Java-Agent layer [**aws-otel-java-agent-<amd64|arm64>-ver-1-26-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS Distro for OpenTelemetry Java Instrumentation `v1.26.0`
+- Collector layer **aws-otel-collector-<amd64|arm64>-ver-0-76-1** contains ADOT Collector for Lambda `v0.29.0`. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+- ADOT Lambda Layers now supports the following confmap providers : file, env, yaml, http, https and s3.
+
+### Download
+
+Learn more about AWS Distro for Open Telemetry Lambda support [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are made upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC).
+
+More blog posts about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) can be found on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).
+
+
+### Author
+
+[Huy Vo](https://github.com/humivo) is a Software Development Engineer on the AWS OpenSource Observability team.

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.29.0.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.29.0 are now available'
 description:
-    May 2023 release announcement for ADOT Lambda layers
+    June 2023 release announcement for ADOT Lambda layers
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"

--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -69,7 +69,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-74-0:1 | Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-76-1:1 | Contains ADOT Collector v0.29.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-go.mdx
+++ b/src/docs/getting-started/lambda/lambda-go.mdx
@@ -87,7 +87,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-74-0:1 | Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-76-1:1 | Contains ADOT Collector v0.29.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -29,7 +29,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-24-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.24.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.24.0) <br/><br/> Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-26-0:1 | Contains [ADOT Java Auto-Instrumentation Agent v1.26.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.26.0) <br/><br/> Contains ADOT Collector v0.29.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -39,7 +39,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-24-0:1 | Contains [OpenTelemetry for Java v1.24.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.24.0) with [Java Instrumentation v1.24.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.24.0) <br/><br/> Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-26-0:1 | Contains [OpenTelemetry for Java v1.26.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.26.0) with [Java Instrumentation v1.26.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.26.0) <br/><br/> Contains ADOT Collector v0.29.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -29,7 +29,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-12-0:1 |Contains [OpenTelemetry for JavaScript v1.12.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.12.0) with [Lambda instrumentation v0.35.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.35.0) <br/><br/> Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-13-0:1 |Contains [OpenTelemetry for JavaScript v1.13.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.13.0) with [Lambda instrumentation v0.35.2](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.35.2) <br/><br/> Contains ADOT Collector v0.29.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -32,7 +32,7 @@ Find the supported regions and amd64(x86_64)/arm64 layer ARN in the table below 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-17-0:1 | Contains [OpenTelemetry Python v1.17.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.17.0) <br/><br/> Contains ADOT Collector v0.28.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-18-0:1 | Contains [OpenTelemetry Python v1.18.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.18.0) <br/><br/> Contains ADOT Collector v0.29.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.


### PR DESCRIPTION
Update the Lambda ARNs and create the release blogs for Lambda Layer release v0.29.0.