### PR TITLE
[PHP manual instrumentation] fix broken links to X-Ray components and deprecated OTLP GRPC exporter

### DIFF
--- a/src/docs/getting-started/php-sdk/trace-manual-instr.mdx
+++ b/src/docs/getting-started/php-sdk/trace-manual-instr.mdx
@@ -31,8 +31,7 @@ Note: You’ll also need to have the [ADOT Collector](https://aws-otel.github.io
 In order to send traces from your application, the following OpenTelemetry PHP packages must be installed in your application’s root directory
 
 
-* [X-Ray ID Generator](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Aws/Xray)
-* [X-Ray propagator](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Aws/Xray)
+* [X-Ray ID Generator and X-Ray Propagator](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Aws/src/Xray)
 
 ```bash
  composer require open-telemetry/contrib-aws
@@ -51,9 +50,9 @@ composer require open-telemetry/sdk
 ```
 
 
-* [OTLP GRPC exporter](https://packagist.org/packages/open-telemetry/exporter-otlp-grpc)
+* [OTLP exporter](https://packagist.org/packages/open-telemetry/exporter-otlp) and [gRPC transport](https://packagist.org/packages/open-telemetry/transport-grpc)
 
-In order to use this package, you must also install the GRPC package using PECL. See the instructions on the [OpenTelemetry PHP repository](https://github.com/open-telemetry/opentelemetry-php#optional-dependencies) for more information.
+In order to use these packages, you must also install the GRPC package using PECL. See the instructions on the [OpenTelemetry PHP repository](https://github.com/open-telemetry/opentelemetry-php/tree/4d9720f19e67bb4f313be53d22552877acf821a9/src/Contrib/Otlp#grpc-transport) for more information.
 
 ```bash
 composer require open-telemetry/exporter-otlp


### PR DESCRIPTION
Fixes #591 

Updated links to: 
- X-Ray ID generator and propagator 
- New composer package links for OTLP export and gRPC transport packages (code snippet for installation is up-to-date, but links were pointing to the deprecated package) 
- Installation guide for gRPC package using PECL