### PR TITLE
Change units for ecs.task.cpu.utilized and ecs.task.cpu.reserved metrics

### DIFF
--- a/src/docs/components/ecs-metrics-receiver.mdx
+++ b/src/docs/components/ecs-metrics-receiver.mdx
@@ -135,8 +135,8 @@ The following table lists all metrics emitted by AWS ECS container metrics recei
 | ecs.task.cpu.usage.vcpu               | container.cpu.usage.vcpu               | vCPU         |
 | ecs.task.cpu.cores                    | container.cpu.cores                    | Count        |
 | ecs.task.cpu.onlines                  | container.cpu.onlines                  | Count        |
-| ecs.task.cpu.reserved                 | container.cpu.reserved                 | None         |
-| ecs.task.cpu.utilized                 | container.cpu.utilized                 | None         |
+| ecs.task.cpu.reserved                 | container.cpu.reserved                 | vCPU         |
+| ecs.task.cpu.utilized                 | container.cpu.utilized                 | Percent      |
 |                                       |                                        |              |
 | ecs.task.network.rate.rx              | container.network.rate.rx              | Bytes/Second |
 | ecs.task.network.rate.tx              | container.network.rate.tx              | Bytes/Second |


### PR DESCRIPTION
Previous [ask](https://github.com/aws-observability/aws-otel-collector/issues/1368#issuecomment-1683287975) in Github issue [#1368](https://github.com/aws-observability/aws-otel-collector/issues/1368) in the aws-otel-collector repo.

Updates the units for the `ecs.task.cpu.utilized` and `ecs.task.cpu.reserved` metrics in the table.