### PR TITLE
[chore] add content for java agent 1.30.0 and fix docs titles

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -9,7 +9,7 @@ blogs:
 
   - title: "AWS Distro for OpenTelemetry Java Instrumentation v1.30.0 is now available"
     author: "Huy Vo"
-    date: "18-September-2023"
+    date: "19-September-2023"
     body:
       "AWS Distro for OpenTelemetry Java Instrumentation v1.30.0 is now available. You can download the latest ADOT Java auto-instrumentation Docker image
         from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery and the jar artifacts from the Maven Central Repository."

--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -7,6 +7,14 @@ path: /blog
 
 blogs:
 
+  - title: "AWS Distro for OpenTelemetry Java Instrumentation v1.30.0 is now available"
+    author: "Huy Vo"
+    date: "18-September-2023"
+    body:
+      "AWS Distro for OpenTelemetry Java Instrumentation v1.30.0 is now available. You can download the latest ADOT Java auto-instrumentation Docker image
+        from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery and the jar artifacts from the Maven Central Repository."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.30.0"
+
   - title: "AWS Distro for OpenTelemetry EKS Add-on v0.80.0 is now available"
     author: "Kausik Amancherla"
     date: "15-September-2023"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.30.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.30.0.mdx
@@ -1,0 +1,38 @@
+---
+title: "AWS Distro for OpenTelemetry Java Instrumentation v1.30.0"
+description: This blog post is the release announcement for AWS Distro for OpenTelemetry - Instrumentation for Java v1.30.0
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) Agent for Java v1.30.0 is now available.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+Contains updates of the following upstream components:
+* OpenTelemetry Java - [1.30.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.30.0)
+* OpenTelemetry Instrumentation for Java - [1.30.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.30.0)
+* OpenTelemetry Java Contrib - [1.29.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.29.0)
+
+
+**Download**
+
+You can download the latest Docker image from [our public ECR repository](https://gallery.ecr.aws/aws-observability/adot-autoinstrumentation-java), and jar artifacts from the
+[GitHub](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.30.0) and [Maven Central Repository](https://central.sonatype.com/artifact/software.amazon.opentelemetry/aws-opentelemetry-agent/1.30.0).
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution,
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html).
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry).
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.30.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.30.0.mdx
@@ -14,7 +14,7 @@ import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.js
 **Release Highlights**
 
 Contains updates of the following upstream components:
-* OpenTelemetry Java - [1.30.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.30.0)
+* OpenTelemetry Java - [1.30.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.30.1)
 * OpenTelemetry Instrumentation for Java - [1.30.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.30.0)
 * OpenTelemetry Java Contrib - [1.29.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.29.0)
 

--- a/src/docs/getting-started/go-sdk.mdx
+++ b/src/docs/getting-started/go-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Getting Started with the OpenTelemetry Go SDK on Traces Instrumentation'
+title: 'Getting Started with the OpenTelemetry Go SDK on Traces and Metrics Instrumentation'
 description:
     OpenTelemetry provides different language SDKs to instrument customer's application for collecting telemetry data.
     In this tutorial, we will introduce how to use OpenTelemetry Go SDK for manual instrumentation

--- a/src/docs/getting-started/java-sdk.mdx
+++ b/src/docs/getting-started/java-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Getting Started with the Java SDK for Traces Instrumentation'
+title: 'Getting Started with the Java SDK for Traces and Metrics Instrumentation'
 description:
     OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
 path: '/docs/getting-started/java-sdk'

--- a/src/docs/getting-started/java-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/auto-instr.mdx
@@ -35,7 +35,7 @@ The ADOT Java Agent is also published in the following maven coordinates:
 
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:1.29.0")
+    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:1.30.0")
 }
 ```
 
@@ -44,7 +44,7 @@ dependencies {
   <dependency>
       <groupId>software.amazon.opentelemetry</groupId>
       <artifactId>aws-opentelemetry-agent</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
   </dependency>
 </dependencies>
 ```
@@ -111,7 +111,7 @@ artifact, any usage of it will be disabled by the agent.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:1.29.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.30.0")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-api</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
   </dependency>
 </dependencies>
 ```

--- a/src/docs/getting-started/java-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/auto-instr.mdx
@@ -111,7 +111,7 @@ artifact, any usage of it will be disabled by the agent.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:1.30.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.30.1")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-api</artifactId>
-    <version>1.30.0</version>
+    <version>1.30.1</version>
   </dependency>
 </dependencies>
 ```

--- a/src/docs/getting-started/java-sdk/manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/manual-instr.mdx
@@ -37,7 +37,7 @@ to align dependency versions for non-contrib components.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry:opentelemetry-bom:1.30.0"))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.30.1"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -46,7 +46,7 @@ dependencies {
 
     implementation("io.opentelemetry:opentelemetry-extension-aws")
     implementation("io.opentelemetry:opentelemetry-sdk-extension-aws")
-    implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.27.0")
+    implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.29.0")
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-bom</artifactId>
-      <version>1.30.0</version>
+      <version>1.30.1</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -87,7 +87,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry.contrib</groupId>
     <artifactId>opentelemetry-aws-xray</artifactId>
-    <version>1.27.0</version>
+    <version>1.29.0</version>
   </dependency>
 </dependencies>
 ```

--- a/src/docs/getting-started/java-sdk/manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/manual-instr.mdx
@@ -37,7 +37,7 @@ to align dependency versions for non-contrib components.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry:opentelemetry-bom:1.29.0"))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.30.0"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -57,7 +57,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-bom</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -211,7 +211,7 @@ library instrumentation. When using this, do not include `opentelemetry-bom`.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.29.0-alpha"))
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.30.0-alpha"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -230,7 +230,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>1.29.0-alpha</version>
+      <version>1.30.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -264,7 +264,7 @@ The `opentelemetry-instrumentation-aws-sdk-2.2` artifact provides instrumentatio
 ##### For Gradle:
 ```java lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.29.0-alpha"))\
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.30.0-alpha"))\
 
     implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2")
 
@@ -279,7 +279,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>1.29.0-alpha</version>
+      <version>1.30.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>

--- a/src/docs/getting-started/python-sdk.mdx
+++ b/src/docs/getting-started/python-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Getting Started with the Python SDK'
+title: 'Getting Started with the Python SDK on Traces and Metrics Instrumentation'
 description:
     OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
     In this tutorial, we will introduce how to use OpenTelemetry Python SDK for traces and metrics instrumentation in the application...
@@ -7,8 +7,6 @@ path: '/docs/getting-started/python-sdk'
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-
-# Getting Started with the Python SDK on Traces and Metrics Instrumentation
 
 The AWS Distro for OpenTelemetry (ADOT) Python refers to some components developed to complement the upstream [OpenTelemetry (OTel) Python SDK](https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk). Below are links to guides that go over how to configure the relevant components of the OpenTelemetry SDK to send trace data to the AWS X-Ray backend.
 

--- a/src/docs/getting-started/ruby-sdk.mdx
+++ b/src/docs/getting-started/ruby-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Getting Started with the ADOT Ruby SDK'
+title: 'Getting Started with the Ruby SDK on Traces Instrumentation'
 description:
     OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
     In this tutorial, we will introduce how to use OpenTelemetry Ruby SDK for traces and metrics instrumentation in the application...
@@ -7,8 +7,6 @@ path: '/docs/getting-started/ruby-sdk'
 ---
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
-
-# Getting Started with the Ruby SDK on Traces Instrumentation
 
 The AWS Distro for OpenTelemetry (ADOT) Ruby refers to some components developed to complement the upstream [OpenTelemetry (OTel) Ruby SDK](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk). Below are links to guides that go over how to configure the relevant components of the OpenTelemetry SDK to send trace data to the AWS X-Ray backend.
 


### PR DESCRIPTION
Updating documentation to point to 1.30.0 and fix the titles of some of the SDK docs

IMPORTANT: DO NOT MERGE THIS PR YET.