### PR TITLE
Usage of right name - AWS Distro For OpenTelemetry

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,11 +5,11 @@ require("dotenv").config({
 module.exports = {
   // pathPrefix: "/",
   siteMetadata: {
-    title: 'AWS Open Distro for OpenTelemetry',
-    siteTitle: `AWS Open Distro for OpenTelemetry`,
-    defaultTitle: `AWS Open Distro for OpenTelemetry`,
+    title: 'AWS Distro for OpenTelemetry',
+    siteTitle: `AWS Distro for OpenTelemetry`,
+    defaultTitle: `AWS Distro for OpenTelemetry`,
     siteTitleShort: `AWS Distro OpenTelemetry`,
-    siteDescription: `Technical documentation for AWS Open Distro for OpenTelemetry`,
+    siteDescription: `Technical documentation for AWS Distro for OpenTelemetry`,
     siteAuthor: `Amazon AWS Observability`,
     // siteImage: `/banner.png`,
     siteLanguage: `en`,

--- a/src/content/Announcements/announcements.yaml
+++ b/src/content/Announcements/announcements.yaml
@@ -1,6 +1,6 @@
 title: Announcements
 description:
-  This page contains all the latest and previous announcements for AWS Open Distro for OpenTelemetry
+  This page contains all the latest and previous announcements for AWS Distro for OpenTelemetry
 path: /announcements
 
 announcements:

--- a/src/content/SiteContent/get-involved.yaml
+++ b/src/content/SiteContent/get-involved.yaml
@@ -1,6 +1,6 @@
 title: Get Involved
 description:
-  This page is about how to get involved with AWS Open Distro for OpenTelemetry
+  This page is about how to get involved with AWS Distro for OpenTelemetry
 path: /get-involved
 
 paragraph1:

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -10,7 +10,7 @@ export default function NotFound() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <Layout title="Page not found!">
         <SEO title="404: Not found" />

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <AboutPage />
     </div>

--- a/src/pages/announcements.js
+++ b/src/pages/announcements.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
       <div>
         <Helmet>
           <meta charSet="utf-8" />
-          <title>AWS Open Distro for OpenTelemetry</title>
+          <title>AWS Distro for OpenTelemetry</title>
         </Helmet>
         <AnnouncementsPage />
       </div>

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <BlogPage />
     </div>

--- a/src/pages/code-of-conduct.js
+++ b/src/pages/code-of-conduct.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <CodeOfConductPage />
     </div>

--- a/src/pages/coming-soon.js
+++ b/src/pages/coming-soon.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <ComingSoonPage />
     </div>

--- a/src/pages/contributing.js
+++ b/src/pages/contributing.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <ContributingPage />
     </div>

--- a/src/pages/contributors.js
+++ b/src/pages/contributors.js
@@ -10,7 +10,7 @@ export default function Contributors() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <ContributorsPage />
     </div>

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -10,7 +10,7 @@ export default function Home() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <DownloadPage />
     </div>

--- a/src/pages/get-involved.js
+++ b/src/pages/get-involved.js
@@ -10,7 +10,7 @@ export default function ComingSoon() {
       <div>
         <Helmet>
           <meta charSet="utf-8" />
-          <title>AWS Open Distro for OpenTelemetry</title>
+          <title>AWS Distro for OpenTelemetry</title>
         </Helmet>
         <GetInvolvedPage />
       </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,7 @@ export default function Home() {
         <div>
         <Helmet>
             <meta charSet="utf-8" />
-            <title>AWS Open Distro for OpenTelemetry</title>
+            <title>AWS Distro for OpenTelemetry</title>
         </Helmet>
         <HomePage
             title="AWS Distro for OpenTelemetry"

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -10,7 +10,7 @@ export default function Resources() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <ResourcesPage />
     </div>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -10,7 +10,7 @@ export default function Home() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <SearchPage />
     </div>

--- a/src/pages/videos.js
+++ b/src/pages/videos.js
@@ -10,7 +10,7 @@ export default function Videos() {
     <div>
       <Helmet>
         <meta charSet="utf-8" />
-        <title>AWS Open Distro for OpenTelemetry</title>
+        <title>AWS Distro for OpenTelemetry</title>
       </Helmet>
       <VideosPage />
     </div>


### PR DESCRIPTION
Use right naming convention for the distro packages