### PR TITLE
Improve env confmap clarity

### DIFF
--- a/src/docs/components/confmap-providers.mdx
+++ b/src/docs/components/confmap-providers.mdx
@@ -38,7 +38,7 @@ The ADOT collector support the following types of confmap providers: file, env, 
 * scheme: `env`. Scheme is optional.
 * description: Retrieves configuration from an environment variable.
 * examples:
-  * `env:ENVIRONMENT_FILE_NAME`
+  * `env:ENVIRONMENT_VARIABLE_NAME`
 
 ### YAML provider
 


### PR DESCRIPTION
`file` -> `variable`. Clarifies that `env:` confmap should point to environment variable. 

https://github.com/open-telemetry/opentelemetry-collector/blob/287b98f6973fd6baa278150b9fca8c83abea0af4/confmap/provider/envprovider/provider.go#L20