### PR TITLE
Update EKS Add-ons docs to better align with AWS Docs site

### DIFF
--- a/src/docs/getting-started/adot-eks-add-on.mdx
+++ b/src/docs/getting-started/adot-eks-add-on.mdx
@@ -24,6 +24,7 @@ import operatorImg2 from "assets/img/docs/gettingStarted/operator/img2.png"
 ### [Kubernetes Attributes Processor](/docs/getting-started/adot-eks-add-on/k8s-attr-processor)
 ### [Target Allocator](/docs/getting-started/adot-eks-add-on/target-allocator)
 ### [Update and Cleanup](/docs/getting-started/adot-eks-add-on/update-and-cleanup)
+### [Troubleshooting](/docs/getting-started/adot-eks-add-on/troubleshooting)
 
 
 ## Introduction

--- a/src/docs/getting-started/adot-eks-add-on.mdx
+++ b/src/docs/getting-started/adot-eks-add-on.mdx
@@ -15,6 +15,7 @@ import operatorImg2 from "assets/img/docs/gettingStarted/operator/img2.png"
 ### [Installation](/docs/getting-started/adot-eks-add-on/installation)
 ### [Add-on Advanced Configuration](/docs/getting-started/adot-eks-add-on/add-on-configuration)
 #### [Add-on Advanced Configuration: Collector Deployment](/docs/getting-started/adot-eks-add-on/add-on-configuration-collector-deployment)
+#### [Deploy a sample app](/docs/getting-started/adot-eks-add-on/sample-app)
 ### [Collector Configuration Introduction](/docs/getting-started/adot-eks-add-on/config-intro)
 #### [Collector Configuration for Amazon Managed Prometheus](/docs/getting-started/adot-eks-add-on/config-amp)
 #### [Collector Configuration for AWS CloudWatch](/docs/getting-started/adot-eks-add-on/config-cloudwatch)

--- a/src/docs/getting-started/adot-eks-add-on/installation.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/installation.mdx
@@ -5,45 +5,61 @@ description:
 path: '/docs/getting-started/adot-eks-add-on/installation'
 ---
 
-The steps to fully deploy ADOT are:
+## Prerequisites
 
-1. Meet the prerequisites described [here](/docs/getting-started/adot-eks-add-on/requirements).
-2. Leverage EKS add-ons to deploy the ADOT Operator to your Amazon EKS cluster.
-3. Deploy the ADOT Collector Custom Resource Definition (CRD). You have the option to associate your IAM role with your EKS service account using [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html). By doing this, your service account can then provide AWS permissions to the containers you run in any pod that use that service account.
++ You have met the [ADOT prerequisites](/docs/getting-started/adot-eks-add-on/requirements)\.
 
-This section will go into detail for the second and third steps. Alternatively, the second and third steps can be simplified, and combined into one, using the EKS add-ons advanced configuration feature. For more information on advanced configuration for ADOT, see [Add-on Advanced Configuration](/docs/getting-started/adot-eks-add-on/add-on-configuration). For more information on ADOT Collector deployment using advanced configuration, see [Add-on Advanced Configuration: Collector Deployment](/docs/getting-started/adot-eks-add-on/add-on-configuration-collector-deployment).
+------
+## AWS Management Console 
 
-## Leverage EKS Add-Ons to deploy the ADOT Operator to your Amazon EKS cluster
+Install the ADOT Amazon EKS add\-on to your Amazon EKS cluster using the following steps:
 
-1. Apply the necessary permissions for ADOT to your cluster with the command:
-```console
-kubectl apply -f https://amazon-eks.s3.amazonaws.com/docs/addons-otel-permissions.yaml
-```
+1. Open the Amazon EKS console at [https://console\.aws\.amazon\.com/eks/home\#/clusters](https://console.aws.amazon.com/eks/home#/clusters)\.
 
-2. Install the ADOT Operator into your Amazon EKS cluster using the command:
-```console
-aws eks create-addon --addon-name adot --cluster-name <your_cluster_name>
-```
+1. In the left pane, select **Clusters**, and then select the name of your cluster on the **Clusters** page\.
 
-The `status` field value will be `CREATING` until complete.
+1. Choose the **Add\-ons** tab\.
 
-`your_cluster_name` is the name of your cluster, you can find it by executing the command below, and a list of cluster names will appear:
-```console
-aws eks list-clusters --region <your_region>
-```
+1. Choose **Get more add\-ons**\.
 
-3. Verify that ADOT is installed and running with the command:
-```console
-aws eks describe-addon --addon-name adot --cluster-name <your_cluster_name>
-```
+1. On the **Select add\-ons** page, do the following:
 
-You'll see `"status": "ACTIVE"` when creation is complete.
+   1. In the **Amazon EKS\-addons** section, select the **AWS Distro for OpenTelemetry** check box\.
 
-### Deploy the ADOT Operator to your Amazon EKS cluster through the EKS console
+   1. Choose **Next**\.
 
-Follow these steps to use the EKS console to leverage EKS add-ons for deploying the ADOT Operator to your Amazon EKS cluster.
+1. On the **Configure selected add\-ons settings** page, do the following:
 
-#### [EKS console instructions](https://docs.aws.amazon.com/eks/latest/userguide/adot-manage.html#adot-install)
+   1. The default version will be selected in the **Version** dropdown list\. Select the **Version** you'd like to use\.
+
+   1. \(Optional\) If deploying an ADOT Collector, expand **Optional configuration settings** and provide the **Configuration values** that match your use case for Collector deployment\. The **Add\-on configuration schema** provides the available options for your configuration values\.
+
+   1. If a service account is already created in the cluster without an IAM role, expand the **Optional configuration settings** and select **Override** for the **Conflict resolution method**\.
+
+   1. Choose **Next**\.
+
+1. On the **Review and add** page, choose **Create**\. After the add\-on installation is complete, you see your installed add\-on\.
+
+------
+## AWS CLI
+
+1. Install the ADOT Amazon EKS add\-on to your Amazon EKS cluster\. Optionally, the `--configuration-values` flag can be added to deploy an ADOT Collector during add\-on installation\. You may also configure other available values with this flag\.
+
+   ```
+   aws eks create-addon --addon-name adot --cluster-name my-cluster --configuration-values my-configuration-values
+   ```
+
+   The `status` field value will be `CREATING` until complete\.
+
+1. Verify that ADOT is installed and running\.
+
+   ```
+   aws eks describe-addon --addon-name adot --cluster-name my-cluster
+   ```
+
+   You'll see `"status": "ACTIVE"` when creation is complete\.
+
+------
 
 ## Deploy the ADOT Collector
 

--- a/src/docs/getting-started/adot-eks-add-on/requirements.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/requirements.mdx
@@ -7,6 +7,8 @@ path: '/docs/getting-started/adot-eks-add-on/requirements'
 
 ## ADOT requirements
 
+* [Connected clusters](https://docs.aws.amazon.com/eks/latest/userguide/eks-connector.html) can't use this add-on.
+
 * [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) is installed
     * There is no specified version, but will be dependent on your cluster’s Kubernetes version (see section below)
     

--- a/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
@@ -20,7 +20,7 @@ procedure in [Install the AWS Distro for OpenTelemetry \(ADOT\) Operator](/docs/
    curl -O https://raw.githubusercontent.com/aws-observability/aws-otel-community/master/sample-configs/traffic-generator.yaml
    ```
 
-1. In `traffic-generator.yaml`, make sure that the second `kind` value reflects your mode\. For more information, 
+2. In `traffic-generator.yaml`, make sure that the second `kind` value reflects your mode\. For more information, 
 see [Deploy the ADOT Collector](https://aws-otel.github.io/docs/getting-started/adot-eks-add-on/installation#deploy-the-adot-collector) on GitHub\.
 
    ```
@@ -30,19 +30,19 @@ see [Deploy the ADOT Collector](https://aws-otel.github.io/docs/getting-started/
    `traffic-generator.yaml` makes `http` calls to the Kubernetes service `sample-app:4567`\. This allows the traffic generator to 
    interact with the sample application on port `4567`\. `sample-app` resolves to the IP address of the `sample-app` Pod\.
 
-1. Apply `traffic-generator.yaml` to your cluster\.
+3. Apply `traffic-generator.yaml` to your cluster\.
 
    ```
    kubectl apply -f traffic-generator.yaml
    ```
 
-1. Download the `sample-app.yaml` file to your computer\. You can also [view the file](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/sample-app.yaml) on GitHub\.
+4. Download the `sample-app.yaml` file to your computer\. You can also [view the file](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/sample-app.yaml) on GitHub\.
 
    ```
    curl -O https://raw.githubusercontent.com/aws-observability/aws-otel-community/master/sample-configs/sample-app.yaml
    ```
 
-1. In `sample-app.yaml`, replace the following with your own AWS Region:
+5. In `sample-app.yaml`, replace the following with your own AWS Region:
 
    ```
    value: "<YOUR_AWS_REGION>"
@@ -56,11 +56,11 @@ see [Deploy the ADOT Collector](https://aws-otel.github.io/docs/getting-started/
      Kubernetes service that allows the sample application to interact with the ADOT Collector on port `4317`\. In the ADOT Collector configuration, 
      the ADOT Collector receives metrics and traces from an endpoint: `0.0.0.0:4317`\. 
 
-1. In `sample-app.yaml`, update the `value` for `OTEL_EXPORTER_OTLP_ENDPOINT` if it doesn't match your collector service name\.
+6. In `sample-app.yaml`, update the `value` for `OTEL_EXPORTER_OTLP_ENDPOINT` if it doesn't match your collector service name\.
 
    For example, X\-Ray requires replacing `http://my-collector-collector:4317` with `http://my-collector-xray-collector:4317`\.
 
-1. Apply `sample-app.yaml` to your cluster\.
+7. Apply `sample-app.yaml` to your cluster\.
 
    ```
    kubectl apply -f sample-app.yaml

--- a/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
@@ -2,7 +2,7 @@
 title: 'Deploy a sample application to test the AWS Distro for OpenTelemetry Collector'
 description:
     This page provides an a sample app that can be used with the Advanced Configuration
-path: '/docs/getting-started/adot-eks-add-on/target-allocator'
+path: '/docs/getting-started/adot-eks-add-on/sample-app'
 ---
 The sample application will generate and send OTLP data to any of the services that you have configured through the AWS Distro for 
 OpenTelemetry [\(ADOT\) Collector deployment](/docs/getting-started/adot-eks-add-on/add-on-configuration-collector-deployment)\. This step is optional if you already have an application running inside your cluster that can produce data\. 

--- a/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/sample-app.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Deploy a sample application to test the AWS Distro for OpenTelemetry Collector'
+description:
+    This page provides an a sample app that can be used with the Advanced Configuration
+path: '/docs/getting-started/adot-eks-add-on/target-allocator'
+---
+The sample application will generate and send OTLP data to any of the services that you have configured through the AWS Distro for 
+OpenTelemetry [\(ADOT\) Collector deployment](/docs/getting-started/adot-eks-add-on/add-on-configuration-collector-deployment)\. This step is optional if you already have an application running inside your cluster that can produce data\. 
+Consult your application's documentation to ensure that data is sent to the correct endpoints\.
+
+The sample application and traffic generator were largely taken from an example in the [ADOT Collector repository](https://github.com/aws-observability/aws-otel-collector/blob/main/examples/docker/docker-compose.yaml)\. 
+A `docker-compose.yaml` file was translated to Kubernetes resources using the [Kompose tool](https://kompose.io/)\.
+
+To apply the traffic generator and sample application, do the following steps\. Make sure that you have satisfied the prerequisites and completed the 
+procedure in [Install the AWS Distro for OpenTelemetry \(ADOT\) Operator](/docs/getting-started/adot-eks-add-on/installation)\. 
+
+1. Download the `traffic-generator.yaml` file to your computer\. You can also [view the file](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/traffic-generator.yaml) on GitHub\.
+
+   ```
+   curl -O https://raw.githubusercontent.com/aws-observability/aws-otel-community/master/sample-configs/traffic-generator.yaml
+   ```
+
+1. In `traffic-generator.yaml`, make sure that the second `kind` value reflects your mode\. For more information, 
+see [Deploy the ADOT Collector](https://aws-otel.github.io/docs/getting-started/adot-eks-add-on/installation#deploy-the-adot-collector) on GitHub\.
+
+   ```
+   kind: Deployment
+   ```
+
+   `traffic-generator.yaml` makes `http` calls to the Kubernetes service `sample-app:4567`\. This allows the traffic generator to 
+   interact with the sample application on port `4567`\. `sample-app` resolves to the IP address of the `sample-app` Pod\.
+
+1. Apply `traffic-generator.yaml` to your cluster\.
+
+   ```
+   kubectl apply -f traffic-generator.yaml
+   ```
+
+1. Download the `sample-app.yaml` file to your computer\. You can also [view the file](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/sample-app.yaml) on GitHub\.
+
+   ```
+   curl -O https://raw.githubusercontent.com/aws-observability/aws-otel-community/master/sample-configs/sample-app.yaml
+   ```
+
+1. In `sample-app.yaml`, replace the following with your own AWS Region:
+
+   ```
+   value: "<YOUR_AWS_REGION>"
+   ```
+
+   The following actions are defined by `sample-app.yaml`:
+   + The Service resource configures `port: 4567` to allow HTTP requests for the traffic generator\.
+   + The Deployment resource configures some environment variables:
+     + The `LISTEN_ADDRESS` is configured to `0.0.0.0:4567` for HTTP requests from the traffic generator\.
+     + The `OTEL_EXPORTER_OTLP_ENDPOINT` has a value of `http://my-collector-collector:4317`\. `my-collector-collector` is the name of the 
+     Kubernetes service that allows the sample application to interact with the ADOT Collector on port `4317`\. In the ADOT Collector configuration, 
+     the ADOT Collector receives metrics and traces from an endpoint: `0.0.0.0:4317`\. 
+
+1. In `sample-app.yaml`, update the `value` for `OTEL_EXPORTER_OTLP_ENDPOINT` if it doesn't match your collector service name\.
+
+   For example, X\-Ray requires replacing `http://my-collector-collector:4317` with `http://my-collector-xray-collector:4317`\.
+
+1. Apply `sample-app.yaml` to your cluster\.
+
+   ```
+   kubectl apply -f sample-app.yaml
+   ```

--- a/src/docs/getting-started/adot-eks-add-on/troubleshooting.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/troubleshooting.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Troubleshooting for ADOT using EKS Add-Ons'
+description:
+    This page presents common troubleshooting for the ADOT EKS Add-on.
+path: '/docs/getting-started/adot-eks-add-on/troubleshooting'
+---
+
+This topic covers some of the common errors that you might encounter while using the AWS Distro for OpenTelemetry (ADOT) Amazon EKS add-on. The topic also includes instructions on how to resolve or workaround the common errors.
+--- 
+### Error: "code": "AccessDenied", "message": "roles.rbac.authorization.k8s.io \"opentelemetry-operator-leader-election-role\" is forbidden: User \"eks:addon-manager\" cannot patch resource \"roles\" in API group \"rbac.authorization.k8s.io\" in the namespace \"opentelemetry-operator-system\"
+
+You don't have permission to install the ADOT for Amazon EKS add-on. See Install the AWS Distro for OpenTelemetry (ADOT) Operator. If you have deleted the add-on and are now reinstalling, make sure that you have applied the required permissions.
+
+### Error: "status": "CREATE_FAILED" or "status": "UPDATE_FAILED"
+
+This can happen due to the following reasons:
+- There might be a conflict. You can overwrite conflicts by adding the `--resolve-conflicts=OVERWRITE` flag and running the create command again.
+- If you're using an add-on version earlier than v0.51.0, you may be on an unsupported architecture, such as arm64. Consult your logs to determine if this is the case. If so, updating your add-on version may resolve this issue because v0.51.0 and later are multi-arch.
+
+### Delete add-on error: "status": "DELETE_FAILED"
+
+You can remove Amazon EKS management of the ADOT Operator add-on by adding the `--preserve` flag to your aws eks delete-addon command.

--- a/src/docs/getting-started/adot-eks-add-on/update-and-cleanup.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/update-and-cleanup.mdx
@@ -5,47 +5,66 @@ description:
 path: '/docs/getting-started/adot-eks-add-on/update-and-cleanup'
 ---
 
-## Updating ADOT using EKS add-ons and Updating the Collector Custom Resource
+## Update the AWS Distro for OpenTelemetry \(ADOT\) Operator<a name="adot-update"></a>
 
-The ADOT Operator and Collector Custom Resource are periodically updated with new versions. Check for an update of the ADOT Operator version EKS add-ons uses by executing the command
-```console
-aws eks describe-addon-versions —addon-name adot
-```
+Amazon EKS does not automatically update ADOT on your cluster\. You must initiate the update and then Amazon EKS updates the Amazon EKS add\-on for you\. 
 
-Refer [here](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) for more information. If a new version is found, update it in your cluster with the command 
-```console
-aws eks update-addon --addon-name adot --addon-version new-addon-version --cluster-name <your_cluster_name>
-```
+**To update the ADOT Amazon EKS add\-on using the AWS CLI**
 
-After updating the ADOT Operator using EKS add-ons, the Collector CR will also have been updated, as the default ADOT Collector image the ADOT Operator uses will have been updated as well. Reapply the Collector configurations with any changes from the last Collector Custom Resource Definition, if necessary.
+1. Check the current version of your ADOT add\-on\. Replace `my-cluster` with your cluster name\.
 
-### Updating ADOT using EKS add-ons advanced configuration feature
+   ```
+   aws eks describe-addon --cluster-name my-cluster --addon-name adot --query "addon.addonVersion" --output text
+   ```
 
-If you followed steps from [Add-on Advanced Configuration](/docs/getting-started/adot-eks-add-on/add-on-configuration), then you can update ADOT using EKS add-ons advanced configuration feature as well. You can execute the command
-```console
-aws eks update-addon --addon-name adot --addon-version new-addon-version --cluster-name <your_cluster_name> --configuration-values <your_configuration_values> 
-```
+1. Determine the ADOT versions are available that are supported by your cluster's version\.
 
-Updating the configuration values used by the add-on with a new JSON string will override previously set configuration values. If you would like to reset the configuration values used back to default values, you can use an empty JSON string (`--configuration-values "{}"`).
+   ```
+   aws eks describe-addon-versions --addon-name adot --kubernetes-version 1.23 \
+       --query "addons[].addonVersions[].[addonVersion, compatibilities[].defaultVersion]" --output text
+   ```
 
-ADOT can also be updated to a new add-on version alongside updates to configuration values. However, the configuration values must be compatible with the add-on version that ADOT is being updated to; the add-on will not update if those configuration values are not available in the new version.
+   An example output is as follows\.
 
-## Cleanup of ADOT using EKS Add-ons and Cleanup of Other Components
+   ```
+   v0.58.0-eksbuild.1
+   True
+   v0.56.0-eksbuild.2
+   False
+   ```
 
-### Delete the Collector resource
+   The version with `True` underneath is the default version deployed when the add\-on is created\. The version deployed when the add\-on is created might not be the latest available version\. In 
+   the previous output, the latest version is deployed when the add\-on is created\.
 
-You can delete individual services by specifying their YAML:
-```console
-kubectl delete -f collector-config-(amp|cloudwatch|xray|advanced).yaml
-```
+1. Update the ADOT version\. Replace `my-cluster` with the name of your cluster and `v0.58.0-eksbuild.1` with the desired version\. Optionally, the `--configuration-values` flag can 
+be added to deploy an ADOT Collector during add\-on installation\. You may also configure other available values with this flag\.
 
-### Uninstall ADOT using EKS Add-Ons
+   ```
+   aws eks update-addon --cluster-name my-cluster --addon-name adot --addon-version v0.58.0-eksbuild.1 --resolve-conflicts PRESERVE --configuration-values my-configuration-values
+   ```
 
-```console
-aws eks delete-addon --addon-name adot --cluster-name your-cluster-name
-```
+   The *PRESERVE* option preserves any custom settings that you've set for the add\-on\. For more information about other options for this setting, see [update\-addon](https://docs.aws.amazon.com/cli/latest/reference/eks/update-addon.html) in the 
+   Amazon EKS Command Line Reference\. For more information about Amazon EKS add\-on configuration management, see [Kubernetes field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html)\.
 
-After uninstalling ADOT, before reinstalling you must reinstall permissions first, see [this page](/docs/getting-started/adot-eks-add-on/requirements#adot-requirements).
+## Remove the AWS Distro for OpenTelemetry \(ADOT\) Operator<a name="adot-remove"></a>
++ You must delete the ADOT Collector resource separately from the ADOT Collector\. In this command, specify the YAML file that you used to deploy the ADOT Collector:
+
+  ```
+  kubectl delete -f collector-config-(amp|cloudwatch|xray|advanced).yaml
+  ```
++ You can remove the ADOT Operator through either the AWS CLI or `eksctl`\. If you remove the ADOT Operator, you must follow the [installation instructions](/docs/getting-started/eks-add-on/installation) again to reinstall:
+
+  CLI
+
+  ```
+  aws eks delete-addon --addon-name adot --cluster-name my-cluster
+  ```
+
+  `eksctl`
+
+  ```
+  eksctl delete addon --cluster my-cluster --name adot
+  ```
 
 ### Uninstall cert-manager
 
@@ -60,7 +79,7 @@ To learn more about how you can use ADOT to collect data for your observability 
 
 ## Troubleshooting Guide
 
-The troubleshooting guide can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/troubleshooting-adot.html).
+The troubleshooting guide can be found [here](/docs/getting-started/adot-eks-add-on/troubleshooting).
 
 ## Previous Topics:
 


### PR DESCRIPTION
This PR aims to better align the ADOT Dev portal with https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html

The installation and update/remove docs have been updated to match instructions from the linked aws docs. These instructions include more thorough console instructions. Added the sample app page that was not present in the ADOT dev portal. Add troubleshooting page that is not present on ADOT dev portal. 