### PR TITLE
Add note about windows nodes support

### DIFF
--- a/src/docs/getting-started/adot-eks-add-on.mdx
+++ b/src/docs/getting-started/adot-eks-add-on.mdx
@@ -26,6 +26,8 @@ import operatorImg2 from "assets/img/docs/gettingStarted/operator/img2.png"
 
 ## Introduction
 
+> **Please note**: Support for Windows Nodes is not currently available.
+
 Welcome to the getting started guide for AWS Distro for OpenTelemetry (ADOT) using Elastic Kubernetes Service (EKS) add-ons. This guide shows you how to leverage Amazon EKS add-ons to install and manage ADOT within your Amazon EKS cluster. [ADOT](https://aws-otel.github.io/) is generally available (GA) for tracing and can also be used for metrics. Amazon EKS add-ons support for ADOT enables a simplified experience through EKS APIs to install one component of ADOT, the [ADOT Operator](/docs/getting-started/adot-eks-add-on#the-adot-operator-and-adot-collector), in your Amazon EKS cluster for your metrics and/or trace collection pipeline. Amazon EKS add-ons support reduces the amount of configuration, setup, and deployment that would be required otherwise. For more information, see [Amazon EKS add-ons](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html).
 
 This guide contains:

--- a/src/docs/getting-started/adot-eks-add-on.mdx
+++ b/src/docs/getting-started/adot-eks-add-on.mdx
@@ -26,8 +26,6 @@ import operatorImg2 from "assets/img/docs/gettingStarted/operator/img2.png"
 
 ## Introduction
 
-> **Please note**: Support for Windows Nodes is not currently available.
-
 Welcome to the getting started guide for AWS Distro for OpenTelemetry (ADOT) using Elastic Kubernetes Service (EKS) add-ons. This guide shows you how to leverage Amazon EKS add-ons to install and manage ADOT within your Amazon EKS cluster. [ADOT](https://aws-otel.github.io/) is generally available (GA) for tracing and can also be used for metrics. Amazon EKS add-ons support for ADOT enables a simplified experience through EKS APIs to install one component of ADOT, the [ADOT Operator](/docs/getting-started/adot-eks-add-on#the-adot-operator-and-adot-collector), in your Amazon EKS cluster for your metrics and/or trace collection pipeline. Amazon EKS add-ons support reduces the amount of configuration, setup, and deployment that would be required otherwise. For more information, see [Amazon EKS add-ons](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html).
 
 This guide contains:

--- a/src/docs/getting-started/adot-eks-add-on/requirements.mdx
+++ b/src/docs/getting-started/adot-eks-add-on/requirements.mdx
@@ -7,6 +7,8 @@ path: '/docs/getting-started/adot-eks-add-on/requirements'
 
 ## ADOT requirements
 
+* Support for Windows Nodes is not currently available.
+
 * [Connected clusters](https://docs.aws.amazon.com/eks/latest/userguide/eks-connector.html) can't use this add-on.
 
 * [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) is installed


### PR DESCRIPTION
Added a note in the ADOT EKS Add-on documentation that mentions support for Windows Nodes is not available so the customer is aware.