### PR TITLE
Chore: Update dependency versions for Java Agent to 1.32.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,14 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry Java Instrumentation v1.32.0 is now available"
+    author: "Paurush Garg"
+    date: "20-Dec-2023"
+    body:
+      "AWS Distro for OpenTelemetry Java Instrumentation v1.32.0 is now available. You can download the latest ADOT Java auto-instrumentation Docker image
+        from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery and the jar artifacts from the Maven Central Repository."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.0"
+
   - title: "AWS Distro for OpenTelemetry Java Instrumentation v1.31.2 is now available"
     author: "Bryan Aguilar"
     date: "15-Dec-2023"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.0.mdx
@@ -13,23 +13,12 @@ import imgJIR1 from "assets/img/blogs/adot-java-instrumentation/Functional_Overv
 <SectionSeparator />
 
 **Release Highlights**
+Contains updates of the following upstream components:
+OpenTelemetry Java - 1.32.0
+OpenTelemetry Instrumentation for Java - 1.32.0
+OpenTelemetry Java Contrib - 1.32.0
 
-* backport 'Null check for nullable response object' to opentelemetry-java-instrumentation [#622]https://github.com/aws-observability/aws-otel-java-instrumentation/pull/622)
-
-
-- ADOT Java Auto-Instrumentation Docker Image
-
-ADOT has released a docker image for the ADOT Java Auto-Instrumentation jar that can be used with OpenTelemetry Operator. This enables OpenTelemetry Operator to auto instrument Java applications by injecting the ADOT Java Agent.
-
-[Opentelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) is an implementation of a Kubernetes Operator. The OpenTelemetry Operator is designed to provide auto-instrumentation to export telemetry data in applications without any code changes. The OpenTelemetry Operator can manage and automate the ADOT Collector deployment in multiple modes (Daemonset, Sidecar, Deployment) as well as auto-instrument workloads using OpenTelemetry libraries.
-
-The ADOT auto-instrumentation for Java is a redistribution of the [OpenTelemetry Agent for Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation) that can be used to auto-instrument Java applications to gather telemetry data. ADOT auto-instrumentation is preconfigured for use with AWS services including support for X-Ray compatible trace IDs. With the release of ADOT Auto-Instrumentation Java Image, OpenTelemetry Operator through Custom Resources can be configured to manage the ADOT Collector and the auto-instrumentation of the workloads (as shown in figure below):
-
-<img src={imgJIR1} alt="Diagram" style="margin: 30px 0;" />
-
-The ADOT Java auto-instrumentation Docker image is available in the following url: https://gallery.ecr.aws/aws-observability/adot-autoinstrumentation-java.
-
-Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-java-instrumentation/releases).
+* Back-ported 'Null check for nullable response object [#10029](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10029)' to opentelemetry-java-instrumentation [#622]https://github.com/aws-observability/aws-otel-java-instrumentation/pull/622)
 
 **Download**
 

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.0.mdx
@@ -1,0 +1,50 @@
+---
+title: "AWS Distro for OpenTelemetry Java Instrumentation v1.32.0"
+description: This blog post is the release announcement for AWS Distro for OpenTelemetry - Instrumentation for Java v1.32.0
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import imgJIR1 from "assets/img/blogs/adot-java-instrumentation/Functional_Overview.png"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) Agent for Java v1.32.0 is now available.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+* backport 'Null check for nullable response object' to opentelemetry-java-instrumentation [#622]https://github.com/aws-observability/aws-otel-java-instrumentation/pull/622)
+
+
+- ADOT Java Auto-Instrumentation Docker Image
+
+ADOT has released a docker image for the ADOT Java Auto-Instrumentation jar that can be used with OpenTelemetry Operator. This enables OpenTelemetry Operator to auto instrument Java applications by injecting the ADOT Java Agent.
+
+[Opentelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) is an implementation of a Kubernetes Operator. The OpenTelemetry Operator is designed to provide auto-instrumentation to export telemetry data in applications without any code changes. The OpenTelemetry Operator can manage and automate the ADOT Collector deployment in multiple modes (Daemonset, Sidecar, Deployment) as well as auto-instrument workloads using OpenTelemetry libraries.
+
+The ADOT auto-instrumentation for Java is a redistribution of the [OpenTelemetry Agent for Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation) that can be used to auto-instrument Java applications to gather telemetry data. ADOT auto-instrumentation is preconfigured for use with AWS services including support for X-Ray compatible trace IDs. With the release of ADOT Auto-Instrumentation Java Image, OpenTelemetry Operator through Custom Resources can be configured to manage the ADOT Collector and the auto-instrumentation of the workloads (as shown in figure below):
+
+<img src={imgJIR1} alt="Diagram" style="margin: 30px 0;" />
+
+The ADOT Java auto-instrumentation Docker image is available in the following url: https://gallery.ecr.aws/aws-observability/adot-autoinstrumentation-java.
+
+Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-java-instrumentation/releases).
+
+**Download**
+
+You can download the latest Docker image from [our public ECR repository](https://gallery.ecr.aws/aws-observability/adot-autoinstrumentation-java), and jar artifacts from the
+[GitHub](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) and [Maven Central Repository](https://central.sonatype.com/artifact/software.amazon.opentelemetry/aws-opentelemetry-agent/1.32.0).
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution,
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html).
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry).
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.

--- a/src/docs/getting-started/java-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/auto-instr.mdx
@@ -35,7 +35,7 @@ The ADOT Java Agent is also published in the following maven coordinates:
 
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:1.31.0")
+    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:1.32.0")
 }
 ```
 
@@ -44,7 +44,7 @@ dependencies {
   <dependency>
       <groupId>software.amazon.opentelemetry</groupId>
       <artifactId>aws-opentelemetry-agent</artifactId>
-      <version>1.31.0</version>
+      <version>1.32.0</version>
   </dependency>
 </dependencies>
 ```
@@ -111,7 +111,7 @@ artifact, any usage of it will be disabled by the agent.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("io.opentelemetry:opentelemetry-api:1.31.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.32.0")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-api</artifactId>
-    <version>1.31.0</version>
+    <version>1.32.0</version>
   </dependency>
 </dependencies>
 ```

--- a/src/docs/getting-started/java-sdk/manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/manual-instr.mdx
@@ -37,7 +37,7 @@ to align dependency versions for non-contrib components.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry:opentelemetry-bom:1.31.0"))
+    api(platform("io.opentelemetry:opentelemetry-bom:1.32.0"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -46,7 +46,7 @@ dependencies {
 
     implementation("io.opentelemetry:opentelemetry-extension-aws")
     implementation("io.opentelemetry:opentelemetry-sdk-extension-aws")
-    implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.31.0")
+    implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.32.0")
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-bom</artifactId>
-      <version>1.31.0</version>
+      <version>1.32.0</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -87,7 +87,7 @@ dependencies {
   <dependency>
     <groupId>io.opentelemetry.contrib</groupId>
     <artifactId>opentelemetry-aws-xray</artifactId>
-    <version>1.31.0</version>
+    <version>1.32.0</version>
   </dependency>
 </dependencies>
 ```
@@ -211,7 +211,7 @@ library instrumentation. When using this, do not include `opentelemetry-bom`.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.31.0-alpha"))
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.32.0-alpha"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -230,7 +230,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>1.31.0-alpha</version>
+      <version>1.32.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -264,7 +264,7 @@ The `opentelemetry-instrumentation-aws-sdk-2.2` artifact provides instrumentatio
 ##### For Gradle:
 ```java lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.31.0-alpha"))\
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.32.0-alpha"))\
 
     implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2")
 
@@ -279,7 +279,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>1.31.0-alpha</version>
+      <version>1.32.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>


### PR DESCRIPTION
Update dependency versions for Java Agent to 1.32.0
Adds blogpost