### PR TITLE
Mention remote sampling support in ADOT Python

### DIFF
--- a/src/docs/getting-started/remote-sampling.mdx
+++ b/src/docs/getting-started/remote-sampling.mdx
@@ -11,9 +11,10 @@ import sampling_attributes from "assets/img/docs/gettingStarted/remote-sampling/
 
 Note that in order to use X-Ray remote sampling, your application's tracer must use an X-Ray sampler. Today the X-Ray sampler is available for the following:
 
-* [ADOT Java agent](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr#using-x-ray-remote-sampling)
+* [ADOT Java auto-instrumentation agent](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-auto-instr#using-x-ray-remote-sampling)
 * [ADOT Java SDK](https://aws-otel.github.io/docs/getting-started/java-sdk/trace-manual-instr#using-x-ray-remote-sampling)
 * [ADOT Go SDK](https://aws-otel.github.io/docs/getting-started/go-sdk/trace-manual-instr#using-x-ray-remote-sampling)
+* [ADOT Python auto-instrumentation agent](https://aws-otel.github.io/docs/getting-started/python-sdk/auto-instr#using-aws-x-ray-remote-sampling)
 
 Enable the extension by adding this snippet to your collector configuration.
 


### PR DESCRIPTION
*Description of changes:*
- This page got left out when we [were updating the docs](https://github.com/aws-otel/aws-otel.github.io/pull/711) for ADOT Python auto-instrumentation: https://aws-otel.github.io/docs/getting-started/remote-sampling#enable-awsproxy-extension
- Adding an entry for ADOT Python remote sampling support
- Also clarifying ADOT Java agent means "ADOT Java auto-instrumentation agent"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
