### PR TITLE
Add Release Blog for ADOT EKS Add on v0.102.0-eksbuild.1

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,13 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry EKS Add-on v0.102.0-eksbuild.1 is now available"
+    author: "Pavan Sai Vasireddy"
+    date: "27-August-2024"
+    body:
+      "AWS Distro for OpenTelemetry EKS Add-on v0.102.0-eksbuild.1 is now available."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.0"
+
   - title: "AWS Distro for OpenTelemetry Collector v0.39.2 is now available"
     author: "Hudson Humphries"
     date: "23-August-2024"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.0.mdx
@@ -1,0 +1,40 @@
+---
+title: 'AWS Distro for OpenTelemetry EKS add-on v0.102.0'
+description:
+    This blog post is the release announcement for ADOT EKS Add-on v0.102.0
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) EKS Add-on v0.102.0 is now available.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+* ADOT Collector [v0.40.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.40.0)
+* ADOT EKS Addon now uses `v1beta1` version of the OTel collector CRD, please refer to [CRD changelog](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/crd-changelog.md) for more details.
+* Support for EKS v1.30
+
+Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-collector/releases).
+All code changes are upstream in the respective OpenTelemetry project components.
+
+**Getting Started**
+
+To learn more about the EKS Add-on please visit the docs on the [ADOT Developer Site](https://aws-otel.github.io/docs/getting-started/adot-eks-add-on) or 
+the [official AWS Docs](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html)
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution,
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html).
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry).
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021 
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.


### PR DESCRIPTION
*Description of changes:*

Add Release Blog for ADOT EKS Add on v0.102.0-eksbuild.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
