### PR TITLE
ADD Release blog for ADOT EKS Add on v0.102.1-eksbuild.2

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,13 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry EKS Add-on v0.102.1-eksbuild.2 is now available"
+    author: "Pavan Sai Vasireddy"
+    date: "23-October-2024"
+    body:
+      "AWS Distro for OpenTelemetry EKS Add-on v0.102.1-eksbuild.2 is now available."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.1-eksbuild.2"
+
   - title: "AWS Distro for OpenTelemetry Java Instrumentation v1.32.4 is now available"
     author: "Michael He"
     date: "16-October-2024"
@@ -13,7 +20,7 @@ blogs:
       "AWS Distro for OpenTelemetry Java Instrumentation v1.32.4 is now available. You can download the latest ADOT Java auto-instrumentation Docker image
           from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery and the jar artifacts from the Maven Central Repository."
     link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v1.32.4"
-    
+
   - title: "AWS Distro for OpenTelemetry Collector v0.41.1 is now available"
     author: "Roy Chiang"
     date: "16-October-2024"
@@ -1144,7 +1151,6 @@ blogs:
       "In this post, three AWS interns—Brandon Kimberly, Ankit Bhargava, and Hudson Humphries—describe their first
       engineering contributions to the popular open source observability project OpenTelemetry."
     link: "https://aws.amazon.com/blogs/opensource/aws-adds-observability-metrics-to-the-opentelemetry-c-library/"
-
 
 searchIndex:
   "

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.1-eksbuild.2.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-eks-add-on-v0.102.1-eksbuild.2.mdx
@@ -1,0 +1,38 @@
+---
+title: 'AWS Distro for OpenTelemetry EKS add-on v0.102.1-eksbuild.2'
+description:
+    This blog post is the release announcement for ADOT EKS Add-on v0.102.1-eksbuild.2
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) EKS Add-on v0.102.1-eksbuild.2 is now available.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+* Upgrade kube-rbac-proxy image version to - `v0.18.1` in the ADOT EKS Add on
+
+Detailed release notes are on [GitHub](https://github.com/aws-observability/aws-otel-collector/releases).
+All code changes are upstream in the respective OpenTelemetry project components.
+
+**Getting Started**
+
+To learn more about the EKS Add-on please visit the docs on the [ADOT Developer Site](https://aws-otel.github.io/docs/getting-started/adot-eks-add-on) or
+the [official AWS Docs](https://docs.aws.amazon.com/eks/latest/userguide/opentelemetry.html)
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution,
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html).
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry).
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.


### PR DESCRIPTION

*Description of changes:*

ADD Release blog for ADOT EKS Add on v0.102.1-eksbuild.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
