### PR TITLE
Update ADOT JS `getting-started` page and links

### DIFF
--- a/src/docs/getting-started/javascript-sdk.mdx
+++ b/src/docs/getting-started/javascript-sdk.mdx
@@ -8,9 +8,7 @@ path: '/docs/getting-started/js-sdk'
 
 import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
 
-OpenTelemetry provides different language SDKs to instrument code for collecting telemetry data in the application.
-
-In this tutorial, we will introduce how to use [OpenTelemetry JavaScript SDK](https://github.com/open-telemetry/opentelemetry-js) for manual instrumentation on traces and metrics in the applications.
+The AWS Distro for OpenTelemetry (ADOT) JavaScript refers to some components developed to complement the upstream [OpenTelemetry (OTel) JavaScript SDK](https://github.com/open-telemetry/opentelemetry-js) and [OTel JavaScript Auto-Instrumentation for Node.js](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node). Below are links to guides that go over how to configure the relevant components of OpenTelemetry to send trace data to the AWS X-Ray backend.
 
 <SectionSeparator />
 
@@ -22,5 +20,6 @@ In this tutorial, we will introduce how to use [OpenTelemetry JavaScript SDK](ht
 
 
 ## Sample Code with JavaScript SDK
-* [AWS Distro for OpenTelemetry Sample Code with JavaScript SDK](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/javascript-sample-app)
+* [Simple Express.js Server Sample Application using ADOT JavaScript Auto-Instrumentation](https://github.com/aws-observability/aws-otel-js-instrumentation/tree/main/sample-applications/simple-express-server)
+* [ADOT Sample Code with JavaScript SDK](https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/javascript-sample-app)
 

--- a/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx
+++ b/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx
@@ -94,4 +94,4 @@ npm install @opentelemetry/api
 
 ## Sample Applications
 
-* [Simple Express.js Server Sample Application](https://github.com/aws-observability/aws-otel-js-instrumentation/tree/main/sample-applications/simple-express-server)
+* [Simple Express.js Server Sample Application using ADOT JavaScript Auto-Instrumentation](https://github.com/aws-observability/aws-otel-js-instrumentation/tree/main/sample-applications/simple-express-server)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update getting-started page to be more similar to [Python](https://aws-otel.github.io/docs/getting-started/python-sdk) and [Java](https://aws-otel.github.io/docs/getting-started/java-sdk), and add more references to `ADOT`.

*Testing:*
Check changes in:
- https://github.com/jj22ee/aws-otel.github.io/blob/test-merge-approval/src/docs/getting-started/javascript-sdk.mdx
- https://github.com/jj22ee/aws-otel.github.io/blob/test-merge-approval/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx#sample-applications

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
