### PR TITLE
Use ubuntu-22.04 in GH workflows runner images

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,11 @@ on:
   push:
     branches:
       - main
-    
+
 
 jobs:
   publish-smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: enriikke/gatsby-gh-pages-action@v2
@@ -21,7 +21,7 @@ jobs:
           access-token: ${{ secrets.demo }}
           deploy-branch: smoke-test
   verify-smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish-smoke-test
     steps:
       - name: Checkout Smoke Test Branch
@@ -56,7 +56,7 @@ jobs:
 
   publish-live:
     needs: verify-smoke-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
     steps:
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION


*Description of changes:*


Use `ubuntu-22.04` instead of `ubuntu-latest` to avoid any breaking changes that comes with `latest`. ubuntu-22.04 is already used as part of ubuntu-latest, so this shall not break any existing workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
