### PR TITLE
Updating documentation to point to 2.10.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,14 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry Java Instrumentation v2.10.0 is now available"
+    author: "Ping Xiang"
+    date: "28-March-2025"
+    body:
+      "AWS Distro for OpenTelemetry Java Instrumentation v2.10.0 is now available. You can download the latest ADOT Java auto-instrumentation Docker image
+          from the Amazon Elastic Container Registry (Amazon ECR) Public Gallery and the jar artifacts from the Maven Central Repository."
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v2.10.0"
+
   - title: "AWS Distro for OpenTelemetry Lambda Layers with ADOT Collector v0.42.0 have been patched and are now available"
     author: "Pavan Sai Vasireddy"
     date: "25-March-2025"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v2.10.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-java-instrumentation-v2.10.0.mdx
@@ -1,0 +1,38 @@
+---
+title: "AWS Distro for OpenTelemetry Java Instrumentation 2.10.0"
+description: This blog post is the release announcement for AWS Distro for OpenTelemetry - Instrumentation for Java 2.10.0
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx";
+import imgJIR1 from "assets/img/blogs/adot-java-instrumentation/Functional_Overview.png"
+
+<SectionSeparator />
+
+[AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/) Agent for Java 2.10.0 is now available.
+
+<SectionSeparator />
+
+**Release Highlights**
+
+Contains the patched version of OpenTelemetry Instrumentation for Java - [2.10.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0)
+
+Check out the release notes for upstream version
+ - https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0
+
+**Download**
+
+You can download the latest Docker image from [our public ECR repository](https://gallery.ecr.aws/aws-observability/adot-autoinstrumentation-java), and jar artifacts from the
+[GitHub](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v2.10.0) and [Maven Central Repository](https://central.sonatype.com/artifact/software.amazon.opentelemetry/aws-opentelemetry-agent/2.10.0).
+
+To learn more about how to use AWS Distro for OpenTelemetry (ADOT) to collect data for your observability solution,
+check out the hands-on [AWS Observability workshop](https://observability.workshop.aws/en/adot.html).
+Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any
+questions about the distribution, features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry).
+The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status
+in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC). Learn more about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/), where we announced
+the distribution’s [general availability for tracing](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-ga-for-tracing/) in September 2021
+and the distribution's [general availability for metrics](https://aws.amazon.com/blogs/opensource/aws-distro-for-opentelemetry-is-now-generally-available-for-metrics/) in May 2022.

--- a/src/docs/getting-started/java-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/auto-instr.mdx
@@ -35,7 +35,7 @@ The ADOT Java Agent is also published in the following maven coordinates:
 
 ```kotlin lineNumbers=true
 dependencies {
-    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:2.0.1")
+    implementation("software.amazon.opentelemetry:aws-opentelemetry-agent:2.10.0")
 }
 ```
 
@@ -44,7 +44,7 @@ dependencies {
   <dependency>
       <groupId>software.amazon.opentelemetry</groupId>
       <artifactId>aws-opentelemetry-agent</artifactId>
-      <version>2.0.1</version>
+      <version>2.10.0</version>
   </dependency>
 </dependencies>
 ```

--- a/src/docs/getting-started/java-sdk/manual-instr.mdx
+++ b/src/docs/getting-started/java-sdk/manual-instr.mdx
@@ -211,7 +211,7 @@ library instrumentation. When using this, do not include `opentelemetry-bom`.
 ##### For Gradle:
 ```kotlin lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.0.1-alpha"))
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.10.0-alpha"))
 
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -230,7 +230,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>2.0.1-alpha</version>
+      <version>2.10.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>
@@ -264,7 +264,7 @@ The `opentelemetry-instrumentation-aws-sdk-2.2` artifact provides instrumentatio
 ##### For Gradle:
 ```java lineNumbers=true
 dependencies {
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.0.1-alpha"))\
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.10.0-alpha"))\
 
     implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2")
 
@@ -279,7 +279,7 @@ dependencies {
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>2.0.1-alpha</version>
+      <version>2.10.0-alpha</version>
       <type>pom</type>
       <scope>import</scope>
     <dependency>


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

Update the doc to point to a new release of ADOT Java Agent (2.10.0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
