### PR TITLE
Update auto-instrumentation docs for AWS OTel GitHub repo

### DIFF
--- a/src/docs/getting-started/dotnet-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/dotnet-sdk/auto-instr.mdx
@@ -50,6 +50,8 @@ automatically when your applicaiton start. For many cases, this is all you need 
 
 ### Configuring Auto-Instrumentation
 
+**Note:** Skip this part if you are onboarding with CloudWatch Application Signals.
+
 By default ADOT .NET auto-Instrumentation uses the [OTLP exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol)
 and is configured to send data to a [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/otlpreceiver/README.md)
 at `http://localhost:4317` for both metrics and traces.

--- a/src/docs/getting-started/java-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/java-sdk/auto-instr.mdx
@@ -66,6 +66,8 @@ automatically. For many cases, this is all you need to use tracing.
 
 ### Configuring Auto-Instrumentation
 
+**Note:** Skip this part if you are onboarding with CloudWatch Application Signals.
+
 By default OpenTelemetry Java agent uses the [OTLP exporter](https://github.com/open-telemetry/opentelemetry-java/tree/master/exporters/otlp)
 and is configured to send data to a [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/otlpreceiver/README.md)
 at `http://localhost:4317` for both metrics and traces.

--- a/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx
+++ b/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx
@@ -56,6 +56,8 @@ node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register'
 
 ### Configuring Auto-Instrumentation
 
+**Note:** Skip this part if you are onboarding with CloudWatch Application Signals.
+
 Environment variables are the primary way in which the OpenTelemetry SDK for JavaScript is configured. For example:
 
 * By default, `@aws/aws-distro-opentelemetry-node-autoinstrumentation` uses the OTLP exporter and is configured to send data to a OpenTelemetry collector at `http://localhost:4318` for both metrics and traces. The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).

--- a/src/docs/getting-started/python-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/auto-instr.mdx
@@ -51,6 +51,8 @@ opentelemetry-instrument python3 ./path/to/your/app.py
 
 ### Configuring Auto-Instrumentation
 
+**Note:** Skip this part if you are onboarding with CloudWatch Application Signals.
+
 Environment variables are the primary way in which the OpenTelemetry SDK for Python is configured. For example:
 
 * By default, `aws-opentelemetry-distro` uses the OTLP exporter and is configured to send data to a OpenTelemetry collector at `http://localhost:4317` for both metrics and traces. The configuration of your SDK exporter depends on how you have configured your ADOT Collector. To learn more about how the ADOT Collector can be configured, refer to the [ADOT Collector Documentation](https://aws-otel.github.io/docs/getting-started/collector).


### PR DESCRIPTION
This change addresses ticket APM-TELEGEN-1782.

Four documentation files have been updated and can be reviewed here:

Dotnet: https://github.com/lukeina2z/aws-otel.github.io/blob/telegen-1782/src/docs/getting-started/dotnet-sdk/auto-instr.mdx#configuring-auto-instrumentation

Java: https://github.com/lukeina2z/aws-otel.github.io/blob/telegen-1782/src/docs/getting-started/java-sdk/auto-instr.mdx#configuring-auto-instrumentation

JavaScript: https://github.com/lukeina2z/aws-otel.github.io/blob/telegen-1782/src/docs/getting-started/js-sdk/trace-metric-auto-instr.mdx#configuring-auto-instrumentation

Python: https://github.com/lukeina2z/aws-otel.github.io/blob/telegen-1782/src/docs/getting-started/python-sdk/auto-instr.mdx#configuring-auto-instrumentation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
