### PR TITLE
update Python SDK minimum supported version from 3.9 to 3.10

### DIFF
--- a/src/docs/getting-started/python-sdk/auto-instr.mdx
+++ b/src/docs/getting-started/python-sdk/auto-instr.mdx
@@ -19,7 +19,7 @@ In this guide, we walk through the steps needed to trace an application and prod
 
 ## Requirements
 
-Python versions 3.9 to 3.14 are required to run an application using OpenTelemetry.
+Python versions 3.10 to 3.14 are required to run an application using OpenTelemetry.
 
 Note: You’ll also need to have the [ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) running to export traces and metrics.
 


### PR DESCRIPTION
### Summary
- Update the minimum supported Python version from 3.9 to 3.10 in the Python SDK auto-instrumentation docs, reflecting the current OpenTelemetry Python SDK support matrix.

DO NOT MERGE YET

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
