### PR TITLE
docs: update Lambda layer ARNs for ADOT Collector v0.48.0

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -72,7 +72,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-117-0:1 | Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-151-0:1 | Contains ADOT Collector v0.48.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-go.mdx
+++ b/src/docs/getting-started/lambda/lambda-go.mdx
@@ -94,7 +94,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-117-0:1 | Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-151-0:1 | Contains ADOT Collector v0.48.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -36,7 +36,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-32-0:6 | Contains [ADOT Java Auto-Instrumentation Agent v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-32-0:7 | Contains [ADOT Java Auto-Instrumentation Agent v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -46,7 +46,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-32-0:6 | Contains [OpenTelemetry for Java v1.32.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.32.0) with [Java Instrumentation v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-32-0:7 | Contains [OpenTelemetry for Java v1.32.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.32.0) with [Java Instrumentation v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -38,7 +38,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-30-2:1 |Contains [OpenTelemetry for JavaScript v1.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0) with [Lambda instrumentation v0.50.3](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.50.3) <br/><br/> Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-30-2:2 |Contains [OpenTelemetry for JavaScript v1.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0) with [Lambda instrumentation v0.50.3](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.50.3) <br/><br/> Contains ADOT Collector v0.48.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -39,7 +39,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-32-0:2 | Contains [OpenTelemetry Python v1.32.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.43.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-32-0:3 | Contains [OpenTelemetry Python v1.32.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.


### PR DESCRIPTION
Update all Lambda layer documentation with new layer versions for the v0.48.0 CVE remediation release.

## Updated layers
| Layer | ARN | Description |
|-------|-----|-------------|
| collector | ver-0-151-0:1 | Was ver-0-117-0:1 |
| java-wrapper | ver-1-32-0:7 | Was ver-1-32-0:6 |
| java-agent | ver-1-32-0:7 | Was ver-1-32-0:6 |
| python | ver-1-32-0:3 | Was ver-1-32-0:2 |
| nodejs | ver-1-30-2:2 | Was ver-1-30-2:1 |

All layers now ship ADOT Collector v0.48.0 (OTel Collector v0.151.0, Go 1.26.2).

## Context
Part of PROMET-11975 / V2153606376 CVE remediation release.