### PR TITLE
Add Lambda Release blog for ADOT Collector v0.48.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,13 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.48.0 are now available"
+    author: "Priyanka Dhingra"
+    date: "13-August-2026"
+    body:
+      "ADOT Lambda Layers now distribute ADOT Collector v0.48.0 with new layers supporting AMD64 and ARM64 Lambda functions"
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.48.0"
+
   - title: "AWS Distro for OpenTelemetry EKS Add-on v0.156.0-eksbuild.1 is now available"
     author: "Lorenzo Spizzuoco"
     date: "27-July-2026"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.48.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.48.0.mdx
@@ -1,0 +1,57 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.48.0 are now available'
+description:
+    August 2026 release announcement for ADOT Lambda layers
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+AWS Distro for OpenTelemetry Lambda Layers now supports AMD64 and ARM64 in the following AWS regions:
+
+|Region                   | AMD64 | ARM64 |
+|-------------------------|-------|-------|
+|Asia Pacific (Mumbai)    |  ✓    |  ✓    |
+|Asia Pacific (Singapore) |  ✓    |  ✓    |
+|Asia Pacific (Sydney)    |  ✓    |  ✓    |
+|Asia Pacific (Tokyo)     |  ✓    |  ✓    |
+|Asia pacific (Seoul)     |  ✓    |  ✓    |
+|Canada (Central)         |  ✓    |  ✓    |
+|Europe (Frankfurt)       |  ✓    |  ✓    |
+|Europe (Ireland)         |  ✓    |  ✓    |
+|Europe (London)          |  ✓    |  ✓    |
+|Europe (Stockholm)       |  ✓    |  ✓    |
+|Europe(Paris)            |  ✓    |  ✓    |
+|South America (Sao Paulo)|  ✓    |  ✓    |
+|US East (N. Virginia)    |  ✓    |  ✓    |
+|US East (Ohio)           |  ✓    |  ✓    |
+|US West (N California)   |  ✓    |  ✓    |
+|US West (Oregon)         |  ✓    |  ✓    |
+
+<SectionSeparator />
+
+### Release Highlights
+
+This release updates the ADOT Collector bundled in every Lambda layer to `v0.48.0` to remediate security vulnerabilities in outdated Go dependencies. The language SDK versions are unchanged from the previous release; only the embedded ADOT Collector was upgraded.
+
+- Python layer [**aws-otel-python-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.32.0` and ADOT Collector for Lambda `v0.48.0`
+- Nodejs layer [**aws-otel-nodejs-<amd64|arm64>-ver-1-30-2**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core `v1.30.0` with AWS Lambda Instrumentation `v0.50.3` and ADOT Collector for Lambda `v0.48.0`
+- Java-Wrapper layer [**aws-otel-java-wrapper-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java `v1.32.0` and ADOT Collector for Lambda `v0.48.0`
+- Java-Agent layer [**aws-otel-java-agent-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS Distro for OpenTelemetry Java Instrumentation `v1.32.0` and ADOT Collector for Lambda `v0.48.0`
+- Collector layer **aws-otel-collector-<amd64|arm64>-ver-0-151-0** contains ADOT Collector for Lambda `v0.48.0`. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+
+### Download
+
+Learn more about AWS Distro for Open Telemetry Lambda support [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are made upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC).
+
+More blog posts about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) can be found on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).
+
+
+### Author
+
+[Priyanka Dhingra](https://github.com/priyankaDhingra) is a SDE on the AWS Open-Source Observability team.


### PR DESCRIPTION
## Description of changes

Adds the release announcement blog for the ADOT Lambda layers that bundle **ADOT Collector v0.48.0**. This is the companion to #846 (which updated the layer ARN tables in the `lambda-*.mdx` docs) — that PR bumped the ARNs but did not add the release blog post or the blog index entry, so this PR fills that gap, matching the pattern established in #786.

This release is a **CVE remediation**: the embedded ADOT Collector was upgraded to v0.48.0 to address outdated Go dependencies. Language SDK versions are unchanged from the prior release.

### Files changed
- **New:** `src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.48.0.mdx` — release blog modeled on the v0.43.0 blog (frontmatter, supported-regions table, Release Highlights, Download, Author).
- **Modified:** `src/content/BlogPosts/blogPosts.yaml` — added a newest-first index entry linking to the new blog.

### Layer versions documented
| Layer | Layer name | Contents |
|-------|-----------|----------|
| Collector | `aws-otel-collector-<arch>-ver-0-151-0` | ADOT Collector v0.48.0 |
| Java-Wrapper | `aws-otel-java-wrapper-<arch>-ver-1-32-0` | OTel Java v1.32.0 + ADOT Collector v0.48.0 |
| Java-Agent | `aws-otel-java-agent-<arch>-ver-1-32-0` | ADOT Java Instrumentation v1.32.0 + ADOT Collector v0.48.0 |
| Python | `aws-otel-python-<arch>-ver-1-32-0` | OTel Python v1.32.0 + ADOT Collector v0.48.0 |
| Nodejs | `aws-otel-nodejs-<arch>-ver-1-30-2` | OTel JS v1.30.0 + Lambda instrumentation v0.50.3 + ADOT Collector v0.48.0 |

### Testing done
- Validated `blogPosts.yaml` parses cleanly with a YAML parser; confirmed the new entry resolves to the new blog link.
- New `.mdx` follows the existing release-blog structure (verified against `aws-distro-for-opentelemetry-lambda-layer-v0.43.0.mdx`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
