### PR TITLE
docs: update Lambda layer ARNs for ADOT Collector v0.49.0

### DIFF
--- a/src/docs/getting-started/lambda/lambda-dotnet.mdx
+++ b/src/docs/getting-started/lambda/lambda-dotnet.mdx
@@ -72,7 +72,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-151-0:1 | Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-156-0:1 | Contains ADOT Collector v0.49.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-go.mdx
+++ b/src/docs/getting-started/lambda/lambda-go.mdx
@@ -94,7 +94,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-151-0:1 | Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-collector-<architecture\>-ver-0-156-0:1 | Contains ADOT Collector v0.49.0 |
 
 ### Enable Tracing
 Once you’ve instrumented the Lambda function code and deployed to Lambda service, you can follow the instructions below to apply Lambda layer.

--- a/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
+++ b/src/docs/getting-started/lambda/lambda-java-auto-instr.mdx
@@ -36,7 +36,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-32-0:7 | Contains [ADOT Java Auto-Instrumentation Agent v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-agent-<architecture\>-ver-1-32-0:8 | Contains [ADOT Java Auto-Instrumentation Agent v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.49.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 

--- a/src/docs/getting-started/lambda/lambda-java.mdx
+++ b/src/docs/getting-started/lambda/lambda-java.mdx
@@ -46,7 +46,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-32-0:7 | Contains [OpenTelemetry for Java v1.32.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.32.0) with [Java Instrumentation v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-java-wrapper-<architecture\>-ver-1-32-0:8 | Contains [OpenTelemetry for Java v1.32.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.32.0) with [Java Instrumentation v1.32.0](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.49.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-js.mdx
+++ b/src/docs/getting-started/lambda/lambda-js.mdx
@@ -38,7 +38,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-30-2:2 |Contains [OpenTelemetry for JavaScript v1.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0) with [Lambda instrumentation v0.50.3](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.50.3) <br/><br/> Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-nodejs-<architecture\>-ver-1-30-2:3 |Contains [OpenTelemetry for JavaScript v1.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0) with [Lambda instrumentation v0.50.3](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/instrumentation-aws-lambda-v0.50.3) <br/><br/> Contains ADOT Collector v0.49.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.

--- a/src/docs/getting-started/lambda/lambda-python.mdx
+++ b/src/docs/getting-started/lambda/lambda-python.mdx
@@ -39,7 +39,7 @@ Find the supported regions and amd64/arm64 layer ARN in the table below for the 
 
 |Supported   Regions  |Lambda layer ARN format  | Contents |
 |---------------------|-------------------------|----------|
-| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-32-0:3 | Contains [OpenTelemetry Python v1.32.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.48.0 |
+| ap-northeast-1<br/>ap-northeast-2<br/>ap-south-1<br/>ap-southeast-1<br/>ap-southeast-2<br/>ca-central-1<br/>eu-central-1<br/>eu-north-1<br/>eu-west-1<br/>eu-west-2<br/>eu-west-3<br/>sa-east-1<br/>us-east-1<br/>us-east-2<br/>us-west-1<br/>us-west-2 | arn:aws:lambda:<region\>:901920570463:layer:aws-otel-python-<architecture\>-ver-1-32-0:4 | Contains [OpenTelemetry Python v1.32.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.32.0) <br/><br/> Contains ADOT Collector v0.49.0 |
 
 ### Enable auto-instrumentation for your Lambda function
 To enable the AWS Distro for OpenTelemetry in your Lambda function, you need to add and configure the layer, and then enable tracing.


### PR DESCRIPTION
## Summary
Updates the Lambda layer ARN tables in all getting-started docs for the ADOT Collector v0.49.0 (OTel Collector v0.156.0) CVE-remediation release (D517814228). MCM step "Update ADOT Lambda layer ARNs in aws-otel.github.io".

## Files & changes (6 mdx)
| Doc | Layer | Version | Collector note |
|-----|-------|---------|----------------|
| lambda-go.mdx / lambda-dotnet.mdx | collector | ver-0-151-0:1 -> ver-0-156-0:1 | v0.48.0 -> v0.49.0 |
| lambda-python.mdx | python | ver-1-32-0:3 -> :4 | v0.48.0 -> v0.49.0 |
| lambda-java.mdx | java-wrapper | ver-1-32-0:7 -> :8 | v0.48.0 -> v0.49.0 |
| lambda-java-auto-instr.mdx | java-agent | ver-1-32-0:7 -> :8 | v0.48.0 -> v0.49.0 |
| lambda-js.mdx | nodejs | ver-1-30-2:2 -> :3 | v0.48.0 -> v0.49.0 |

## Testing
- Version suffixes taken from the published prod layer_*.tf artifacts (acct 901920570463).
- java-wrapper uses :8 (dominant version; matches single-templated-ARN convention from prior release #846). Note: arm64 us-east-1 published as :9; exact per-region ARNs are carried in sample-app tf + aws-cdk fact table.

## Related
- Sample-app ARNs: aws-otel-lambda#1147
- CHANGELOG/README: aws-otel-lambda#1148
- Blog post: follow-up PR
