### PR TITLE
Add Lambda Release blog for ADOT Collector v0.49.0

### DIFF
--- a/src/content/BlogPosts/blogPosts.yaml
+++ b/src/content/BlogPosts/blogPosts.yaml
@@ -6,6 +6,13 @@ description:
 path: /blog
 
 blogs:
+  - title: "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.49.0 are now available"
+    author: "Priyanka Dhingra"
+    date: "25-August-2026"
+    body:
+      "ADOT Lambda Layers now distribute ADOT Collector v0.49.0 (OTel Collector v0.156.0) with new layers supporting AMD64 and ARM64 Lambda functions, remediating 34 CVEs"
+    link: "/docs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.49.0"
+
   - title: "AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.48.0 are now available"
     author: "Priyanka Dhingra"
     date: "13-August-2026"

--- a/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.49.0.mdx
+++ b/src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.49.0.mdx
@@ -1,0 +1,57 @@
+---
+title: 'AWS Distro for OpenTelemetry Lambda Layers that contains ADOT Collector v0.49.0 are now available'
+description:
+    August 2026 release announcement for ADOT Lambda layers
+---
+
+import SectionSeparator from "components/MdxSectionSeparator/sectionSeparator.jsx"
+
+<SectionSeparator />
+
+AWS Distro for OpenTelemetry Lambda Layers now supports AMD64 and ARM64 in the following AWS regions:
+
+|Region                   | AMD64 | ARM64 |
+|-------------------------|-------|-------|
+|Asia Pacific (Mumbai)    |  ✓    |  ✓    |
+|Asia Pacific (Singapore) |  ✓    |  ✓    |
+|Asia Pacific (Sydney)    |  ✓    |  ✓    |
+|Asia Pacific (Tokyo)     |  ✓    |  ✓    |
+|Asia pacific (Seoul)     |  ✓    |  ✓    |
+|Canada (Central)         |  ✓    |  ✓    |
+|Europe (Frankfurt)       |  ✓    |  ✓    |
+|Europe (Ireland)         |  ✓    |  ✓    |
+|Europe (London)          |  ✓    |  ✓    |
+|Europe (Stockholm)       |  ✓    |  ✓    |
+|Europe(Paris)            |  ✓    |  ✓    |
+|South America (Sao Paulo)|  ✓    |  ✓    |
+|US East (N. Virginia)    |  ✓    |  ✓    |
+|US East (Ohio)           |  ✓    |  ✓    |
+|US West (N California)   |  ✓    |  ✓    |
+|US West (Oregon)         |  ✓    |  ✓    |
+
+<SectionSeparator />
+
+### Release Highlights
+
+This release updates the ADOT Collector bundled in every Lambda layer to `v0.49.0` (OpenTelemetry Collector `v0.156.0`, Go 1.26.4) to remediate 34 security vulnerabilities (8 critical, 13 high, 12 medium, 1 low) reported in outdated Go dependencies. The language SDK versions are unchanged from the previous release; only the embedded ADOT Collector was upgraded.
+
+- Python layer [**aws-otel-python-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.32.0` and ADOT Collector for Lambda `v0.49.0`
+- Nodejs layer [**aws-otel-nodejs-<amd64|arm64>-ver-1-30-2**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript Core `v1.30.0` with AWS Lambda Instrumentation `v0.50.3` and ADOT Collector for Lambda `v0.49.0`
+- Java-Wrapper layer [**aws-otel-java-wrapper-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java `v1.32.0` and ADOT Collector for Lambda `v0.49.0`
+- Java-Agent layer [**aws-otel-java-agent-<amd64|arm64>-ver-1-32-0**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS Distro for OpenTelemetry Java Instrumentation `v1.32.0` and ADOT Collector for Lambda `v0.49.0`
+- Collector layer **aws-otel-collector-<amd64|arm64>-ver-0-156-0** contains ADOT Collector for Lambda `v0.49.0`. Compatible with [.NET](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) and [Go](https://aws-otel.github.io/docs/getting-started/lambda/lambda-go) runtimes.
+
+### Download
+
+Learn more about AWS Distro for Open Telemetry Lambda support [here](https://aws-otel.github.io/docs/getting-started/lambda). All code changes are made upstream in the respective OpenTelemetry project components. Please file an [issue](https://github.com/aws-observability/aws-otel-community/issues) if you have any questions about the features, or its components.
+
+We also welcome you to participate in the [OpenTelemetry project](https://github.com/open-telemetry). The project was [approved for incubation](https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/) status in August 2021 by the Cloud Native Computing Foundation Technical Oversight Committee (CNCF TOC).
+
+More blog posts about
+[AWS Distro for OpenTelemetry](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/) can be found on the
+[AWS Open Source Blog](https://aws.amazon.com/blogs/opensource/category/management-tools/aws-distro-for-opentelemetry/).
+
+
+### Author
+
+[Priyanka Dhingra](https://github.com/priyankaDhingra) is a SDE on the AWS Open-Source Observability team.


### PR DESCRIPTION
## Summary
Adds the release blog post for the ADOT Collector v0.49.0 (OTel Collector v0.156.0) CVE-remediation Lambda layer release (D517814228). Mirrors the prior v0.48.0 blog (#848). MCM step "Update aws-otel.github.io" (blog half).

## Changes
- New: src/content/Blogs/ReleaseBlogs/aws-distro-for-opentelemetry-lambda-layer-v0.49.0.mdx
- Updated: src/content/BlogPosts/blogPosts.yaml (new entry prepended)

## Related
- Docs ARN tables: aws-otel.github.io#850
- Sample-app ARNs: aws-otel-lambda#1147 (merged)
- CHANGELOG/README: aws-otel-lambda#1148 (merged)

